### PR TITLE
Contact map view with Mapbox geocoding

### DIFF
--- a/backend/alembic/versions/b7c8d9e0f1a2_add_contact_coordinates.py
+++ b/backend/alembic/versions/b7c8d9e0f1a2_add_contact_coordinates.py
@@ -1,0 +1,35 @@
+"""add contact coordinates
+
+Revision ID: b7c8d9e0f1a2
+Revises: b1c2d3e4f5a6
+Create Date: 2026-04-14
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b7c8d9e0f1a2"
+down_revision = "b1c2d3e4f5a6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("contacts", sa.Column("latitude", sa.Float(), nullable=True))
+    op.add_column("contacts", sa.Column("longitude", sa.Float(), nullable=True))
+    op.add_column("contacts", sa.Column("geocoded_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("contacts", sa.Column("geocoded_location", sa.String(), nullable=True))
+    op.create_index(
+        "ix_contacts_user_latlng",
+        "contacts",
+        ["user_id", "latitude", "longitude"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_contacts_user_latlng", table_name="contacts")
+    op.drop_column("contacts", "geocoded_location")
+    op.drop_column("contacts", "geocoded_at")
+    op.drop_column("contacts", "longitude")
+    op.drop_column("contacts", "latitude")

--- a/backend/app/api/contacts.py
+++ b/backend/app/api/contacts.py
@@ -6,6 +6,7 @@ from app.api.contacts_routes.duplicates import router as duplicates_router
 from app.api.contacts_routes.imports import router as imports_router
 from app.api.contacts_routes.sync import router as sync_router
 from app.api.contacts_routes.messaging import router as messaging_router
+from app.api.contacts_routes.map import router as map_router
 
 router = APIRouter()
 # CRITICAL: Include order matters — static routes BEFORE parameterized
@@ -14,6 +15,7 @@ router.include_router(taxonomy_router)
 router.include_router(listing_router)
 router.include_router(imports_router)
 router.include_router(sync_router)
+router.include_router(map_router)
 router.include_router(crud_router)
 router.include_router(duplicates_router)
 router.include_router(messaging_router)

--- a/backend/app/api/contacts_routes/map.py
+++ b/backend/app/api/contacts_routes/map.py
@@ -1,0 +1,60 @@
+"""GET /api/v1/contacts/map — pins within a bounding box."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user
+from app.core.database import get_db
+from app.models.contact import Contact
+from app.models.user import User
+from app.schemas.contact import ContactMapPin
+from app.schemas.responses import Envelope
+
+router = APIRouter(prefix="/api/v1/contacts", tags=["contacts"])
+
+_HARD_LIMIT = 500
+
+
+@router.get("/map", response_model=Envelope[list[ContactMapPin]])
+async def contacts_map(
+    bbox: str = Query(..., description="minLng,minLat,maxLng,maxLat"),
+    limit: int = Query(500, ge=1, le=2000),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> Envelope[list[ContactMapPin]]:
+    parts = bbox.split(",")
+    if len(parts) != 4:
+        raise HTTPException(status_code=400, detail="bbox must be minLng,minLat,maxLng,maxLat")
+    try:
+        min_lng, min_lat, max_lng, max_lat = (float(p) for p in parts)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="bbox must be minLng,minLat,maxLng,maxLat")
+
+    effective_limit = min(limit, _HARD_LIMIT)
+
+    where = [
+        Contact.user_id == user.id,
+        Contact.latitude.is_not(None),
+        Contact.longitude.is_not(None),
+        Contact.latitude >= min_lat,
+        Contact.latitude <= max_lat,
+        Contact.longitude >= min_lng,
+        Contact.longitude <= max_lng,
+    ]
+    total = (
+        await db.execute(select(func.count()).select_from(Contact).where(*where))
+    ).scalar_one()
+    rows = (
+        await db.execute(
+            select(Contact)
+            .where(*where)
+            .order_by(Contact.relationship_score.desc())
+            .limit(effective_limit)
+        )
+    ).scalars().all()
+    return Envelope(
+        data=[ContactMapPin.model_validate(c) for c in rows],
+        meta={"total_in_bounds": total},
+    )

--- a/backend/app/api/map.py
+++ b/backend/app/api/map.py
@@ -1,0 +1,21 @@
+"""Map-related client config (public Mapbox token, etc.)."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.core.auth import get_current_user
+from app.core.config import settings
+from app.models.user import User
+from app.schemas.responses import Envelope
+
+router = APIRouter(prefix="/api/v1/map", tags=["map"])
+
+
+class MapConfig(BaseModel):
+    mapbox_public_token: str
+
+
+@router.get("/config", response_model=Envelope[MapConfig])
+async def map_config(_: User = Depends(get_current_user)) -> Envelope[MapConfig]:
+    return Envelope(data=MapConfig(mapbox_public_token=settings.MAPBOX_PUBLIC_TOKEN))

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,6 +42,9 @@ class Settings(BaseSettings):
 
     APOLLO_API_KEY: str = ""
 
+    MAPBOX_SECRET_TOKEN: str = ""  # server-side geocoding
+    MAPBOX_PUBLIC_TOKEN: str = ""  # surfaced to browser for map tiles
+
     ENCRYPTION_KEY: str = ""
 
     CORS_ORIGINS: list[str] = ["http://localhost:3000", "http://127.0.0.1:3000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.api.sync_history import router as sync_history_router
 from app.api.whatsapp import router as whatsapp_router
 from app.api.meta import router as meta_router
 from app.api.twitter_cookies import router as twitter_cookies_router
+from app.api.map import router as map_router
 
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -101,6 +102,7 @@ app.include_router(sync_history_router)
 app.include_router(whatsapp_router)
 app.include_router(meta_router)
 app.include_router(twitter_cookies_router)
+app.include_router(map_router)
 
 # MCP SSE endpoint — manually assembled to avoid the mcp library's
 # sse_app() bug: it wraps the SSE ASGI handler in a request-response

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,9 @@ from app.models.organization import Organization
 from app.models.tag_taxonomy import TagTaxonomy
 from app.models.user import User
 
+# Register SQLAlchemy event listeners (must import to execute @event.listens_for)
+from app.models import listeners  # noqa: F401,E402
+
 __all__ = [
     "User",
     "Contact",

--- a/backend/app/models/contact.py
+++ b/backend/app/models/contact.py
@@ -2,7 +2,7 @@ import hashlib
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, func
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -51,6 +51,10 @@ class Contact(Base):
     telegram_bio: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     location: Mapped[str | None] = mapped_column(String, nullable=True)
+    latitude: Mapped[float | None] = mapped_column(Float, nullable=True)
+    longitude: Mapped[float | None] = mapped_column(Float, nullable=True)
+    geocoded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    geocoded_location: Mapped[str | None] = mapped_column(String, nullable=True)
     linkedin_url: Mapped[str | None] = mapped_column(String, nullable=True)
     linkedin_profile_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
     linkedin_headline: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/app/models/listeners.py
+++ b/backend/app/models/listeners.py
@@ -1,0 +1,43 @@
+"""SQLAlchemy event listeners for side-effects on model changes."""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import event, inspect
+from sqlalchemy.orm import Session
+
+from app.models.contact import Contact
+from app.services.task_jobs.geocoding import geocode_contact
+
+_log = logging.getLogger(__name__)
+
+
+@event.listens_for(Session, "after_flush")
+def _enqueue_geocode(session: Session, flush_context) -> None:
+    targets: list[Contact] = []
+    for obj in session.new:
+        if isinstance(obj, Contact) and obj.location:
+            targets.append(obj)
+    for obj in session.dirty:
+        if not isinstance(obj, Contact):
+            continue
+        state = inspect(obj)
+        hist = state.attrs.location.history
+        if hist.has_changes():
+            targets.append(obj)
+
+    if not targets:
+        return
+
+    def _fire(_session):
+        for c in targets:
+            try:
+                geocode_contact.delay(str(c.id))
+            except Exception:
+                _log.warning(
+                    "geocode_contact enqueue failed",
+                    extra={"provider": "celery", "contact_id": str(c.id)},
+                    exc_info=True,
+                )
+
+    event.listen(session, "after_commit", _fire, once=True)

--- a/backend/app/schemas/contact.py
+++ b/backend/app/schemas/contact.py
@@ -125,6 +125,8 @@ class ContactResponse(ContactBase):
     last_followup_at: datetime | None = None
     user_edited_fields: list[str] = []
     bcc_hash: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
     created_at: datetime
     updated_at: datetime | None = None
 
@@ -141,6 +143,17 @@ class PaginationMeta(BaseModel):
     page: int
     page_size: int
     total_pages: int
+
+
+class ContactMapPin(BaseModel):
+    id: uuid.UUID
+    full_name: str | None
+    avatar_url: str | None
+    latitude: float
+    longitude: float
+    relationship_score: int
+
+    model_config = {"from_attributes": True}
 
 
 class ContactListResponse(BaseModel):

--- a/backend/app/services/geocoding/__init__.py
+++ b/backend/app/services/geocoding/__init__.py
@@ -1,0 +1,11 @@
+from app.services.geocoding.exceptions import (
+    GeocodingError,
+    GeocodingNotFoundError,
+    GeocodingRateLimitError,
+)
+
+__all__ = [
+    "GeocodingError",
+    "GeocodingNotFoundError",
+    "GeocodingRateLimitError",
+]

--- a/backend/app/services/geocoding/__init__.py
+++ b/backend/app/services/geocoding/__init__.py
@@ -3,9 +3,12 @@ from app.services.geocoding.exceptions import (
     GeocodingNotFoundError,
     GeocodingRateLimitError,
 )
+from app.services.geocoding.mapbox import GeocodeResult, MapboxGeocoder
 
 __all__ = [
+    "GeocodeResult",
     "GeocodingError",
     "GeocodingNotFoundError",
     "GeocodingRateLimitError",
+    "MapboxGeocoder",
 ]

--- a/backend/app/services/geocoding/exceptions.py
+++ b/backend/app/services/geocoding/exceptions.py
@@ -1,0 +1,10 @@
+class GeocodingError(Exception):
+    """Base class for geocoding failures."""
+
+
+class GeocodingRateLimitError(GeocodingError):
+    """Retryable: provider rate-limited the request."""
+
+
+class GeocodingNotFoundError(GeocodingError):
+    """Terminal: provider returned no match for the input."""

--- a/backend/app/services/geocoding/mapbox.py
+++ b/backend/app/services/geocoding/mapbox.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+from app.services.geocoding.exceptions import (
+    GeocodingError,
+    GeocodingNotFoundError,
+    GeocodingRateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+_ENDPOINT = "https://api.mapbox.com/search/geocode/v6/forward"
+_TIMEOUT = httpx.Timeout(10.0)
+_MAX_RETRIES = 3
+
+
+@dataclass(frozen=True)
+class GeocodeResult:
+    latitude: float
+    longitude: float
+
+
+class MapboxGeocoder:
+    def __init__(self, token: str, client: httpx.AsyncClient | None = None) -> None:
+        if not token:
+            raise GeocodingError("Mapbox token is not configured")
+        self._token = token
+        self._client = client
+
+    async def geocode(self, query: str) -> GeocodeResult:
+        params = {"q": query, "access_token": self._token, "limit": 1}
+        last_exc: Exception | None = None
+        for attempt in range(_MAX_RETRIES):
+            try:
+                async with self._session() as client:
+                    resp = await client.get(_ENDPOINT, params=params, timeout=_TIMEOUT)
+                if resp.status_code == 429:
+                    raise GeocodingRateLimitError("Mapbox rate limit")
+                if 500 <= resp.status_code < 600:
+                    last_exc = GeocodingError(f"Mapbox 5xx: {resp.status_code}")
+                    continue
+                if resp.status_code >= 400:
+                    logger.warning(
+                        "Mapbox 4xx",
+                        extra={"provider": "mapbox", "status": resp.status_code, "query": query},
+                    )
+                    raise GeocodingNotFoundError(f"Mapbox client error: {resp.status_code}")
+                data = resp.json()
+                features = data.get("features") or []
+                if not features:
+                    raise GeocodingNotFoundError("No results")
+                lng, lat = features[0]["geometry"]["coordinates"]
+                return GeocodeResult(latitude=float(lat), longitude=float(lng))
+            except (httpx.TimeoutException, httpx.TransportError) as exc:
+                last_exc = exc
+                continue
+            except GeocodingRateLimitError:
+                raise
+            except GeocodingNotFoundError:
+                raise
+        logger.warning(
+            "Mapbox exhausted retries",
+            extra={"provider": "mapbox", "query": query},
+            exc_info=last_exc,
+        )
+        raise GeocodingError(f"Mapbox failed after {_MAX_RETRIES} attempts: {last_exc}")
+
+    def _session(self):
+        if self._client is not None:
+            return _NoopCM(self._client)
+        return httpx.AsyncClient()
+
+
+class _NoopCM:
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._c = client
+
+    async def __aenter__(self) -> httpx.AsyncClient:
+        return self._c
+
+    async def __aexit__(self, *args: object) -> None:
+        return None

--- a/backend/app/services/task_jobs/geocoding.py
+++ b/backend/app/services/task_jobs/geocoding.py
@@ -1,0 +1,102 @@
+"""Geocoding Celery tasks — resolve Contact.location to lat/lng via Mapbox."""
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from celery import shared_task
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.celery_app import celery_app  # noqa: F401 — registers the app
+from app.core.config import settings
+from app.core.database import task_session
+from app.models.contact import Contact
+from app.services.geocoding import (
+    GeocodingError,
+    GeocodingNotFoundError,
+    GeocodingRateLimitError,
+    MapboxGeocoder,
+)
+from app.services.task_jobs.common import _run, logger
+
+_geocoder: MapboxGeocoder | None = (
+    MapboxGeocoder(token=settings.MAPBOX_SECRET_TOKEN)
+    if settings.MAPBOX_SECRET_TOKEN
+    else None
+)
+
+
+async def _do_geocode(
+    session: AsyncSession,
+    contact_id: str,
+    geocoder: MapboxGeocoder,
+) -> None:
+    """Geocode a single contact, updating its lat/lng/geocoded_* fields.
+
+    Idempotent: no-op if geocoded_location already matches the current location.
+    """
+    contact = (
+        await session.execute(
+            select(Contact).where(Contact.id == uuid.UUID(contact_id))
+        )
+    ).scalar_one_or_none()
+    if contact is None:
+        logger.info("geocode_contact: contact gone", extra={"contact_id": contact_id})
+        return
+    if contact.geocoded_location == contact.location:
+        return
+    now = datetime.now(UTC)
+    if not contact.location:
+        contact.latitude = None
+        contact.longitude = None
+        contact.geocoded_location = None
+        contact.geocoded_at = now
+        await session.commit()
+        return
+    try:
+        result = await geocoder.geocode(contact.location)
+    except GeocodingNotFoundError:
+        logger.info(
+            "geocode returned no match",
+            extra={
+                "provider": "mapbox",
+                "contact_id": contact_id,
+                "location": contact.location,
+            },
+        )
+        contact.latitude = None
+        contact.longitude = None
+        contact.geocoded_location = contact.location
+        contact.geocoded_at = now
+        await session.commit()
+        return
+    contact.latitude = result.latitude
+    contact.longitude = result.longitude
+    contact.geocoded_location = contact.location
+    contact.geocoded_at = now
+    await session.commit()
+
+
+@shared_task(
+    name="app.services.tasks.geocode_contact",
+    autoretry_for=(GeocodingRateLimitError, GeocodingError),
+    retry_backoff=True,
+    retry_backoff_max=600,
+    max_retries=5,
+    rate_limit="500/m",
+)
+def geocode_contact(contact_id: str) -> None:
+    """Celery entry point — geocode a single contact by id."""
+    if _geocoder is None:
+        logger.info(
+            "Mapbox token not configured, skipping geocode",
+            extra={"contact_id": contact_id},
+        )
+        return
+
+    async def _runner() -> None:
+        async with task_session() as session:
+            await _do_geocode(session, contact_id, _geocoder)
+
+    _run(_runner())

--- a/backend/app/services/task_jobs/geocoding.py
+++ b/backend/app/services/task_jobs/geocoding.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import UTC, datetime
 
 from celery import shared_task
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.celery_app import celery_app  # noqa: F401 — registers the app
@@ -100,3 +100,35 @@ def geocode_contact(contact_id: str) -> None:
             await _do_geocode(session, contact_id, _geocoder)
 
     _run(_runner())
+
+
+async def _do_backfill(session: AsyncSession) -> int:
+    """Enqueue geocode_contact for every contact that needs geocoding.
+
+    Returns the number of contacts enqueued.
+    """
+    rows = await session.execute(
+        select(Contact.id).where(
+            Contact.location.is_not(None),
+            Contact.location != "",
+            or_(
+                Contact.geocoded_location.is_(None),
+                Contact.geocoded_location != Contact.location,
+            ),
+        )
+    )
+    count = 0
+    for (cid,) in rows:
+        geocode_contact.delay(str(cid))
+        count += 1
+    return count
+
+
+@shared_task(name="app.services.tasks.backfill_all_contacts")
+def backfill_all_contacts() -> int:
+    """Admin task: enqueue geocode_contact for all contacts needing coordinates."""
+    async def _runner() -> int:
+        async with task_session() as session:
+            return await _do_backfill(session)
+
+    return _run(_runner())

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,0 +1,12697 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "PingCRM API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/v1/contacts/tags/discover": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Discover Tag Taxonomy",
+        "description": "Phase 1: AI scans all contacts and proposes a categorized tag taxonomy.",
+        "operationId": "discover_tag_taxonomy_api_v1_contacts_tags_discover_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TaxonomyResult_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/tags/taxonomy": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Get Taxonomy",
+        "description": "Get the current user's tag taxonomy.",
+        "operationId": "get_taxonomy_api_v1_contacts_tags_taxonomy_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TaxonomyResult_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Update Taxonomy",
+        "description": "Update the user's tag taxonomy (add/remove/rename categories and tags).",
+        "operationId": "update_taxonomy_api_v1_contacts_tags_taxonomy_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaxonomyUpdateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TaxonomyResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/tags/apply": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Apply Tags",
+        "description": "Phase 2: Apply approved taxonomy tags to contacts (inline for <20, Celery for more).",
+        "operationId": "apply_tags_api_v1_contacts_tags_apply_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplyTagsBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ApplyTagsResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/{contact_id}/auto-tag": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Auto Tag Contact",
+        "description": "Quick single-contact auto-tagging using the approved taxonomy.",
+        "operationId": "auto_tag_contact_api_v1_contacts__contact_id__auto_tag_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_AutoTagResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "List Contacts",
+        "operationId": "list_contacts_api_v1_contacts_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tag"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "name": "score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by score tier: strong (8-10), active (4-7), dormant (0-3)",
+              "title": "Score"
+            },
+            "description": "Filter by score tier: strong (8-10), active (4-7), dormant (0-3)"
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter contacts created on or after this date (YYYY-MM-DD)",
+              "title": "Date From"
+            },
+            "description": "Filter contacts created on or after this date (YYYY-MM-DD)"
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter contacts created on or before this date (YYYY-MM-DD)",
+              "title": "Date To"
+            },
+            "description": "Filter contacts created on or before this date (YYYY-MM-DD)"
+          },
+          {
+            "name": "has_interactions",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to contacts with (true) or without (false) interactions",
+              "title": "Has Interactions"
+            },
+            "description": "Filter to contacts with (true) or without (false) interactions"
+          },
+          {
+            "name": "interaction_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 365,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to contacts with last interaction within N days",
+              "title": "Interaction Days"
+            },
+            "description": "Filter to contacts with last interaction within N days"
+          },
+          {
+            "name": "has_birthday",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to contacts with (true) or without (false) a birthday set",
+              "title": "Has Birthday"
+            },
+            "description": "Filter to contacts with (true) or without (false) a birthday set"
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by priority level: high, medium, low",
+              "title": "Priority"
+            },
+            "description": "Filter by priority level: high, medium, low"
+          },
+          {
+            "name": "archived_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Return only archived contacts",
+              "default": false,
+              "title": "Archived Only"
+            },
+            "description": "Return only archived contacts"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^(score|created|interaction|birthday|company|activity|overdue|priority)$",
+              "default": "score",
+              "title": "Sort"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContactListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Create Contact",
+        "operationId": "create_contact_api_v1_contacts_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContactCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ContactResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/ids": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "List Contact Ids",
+        "description": "Return all matching contact IDs (no pagination) for bulk select-all.",
+        "operationId": "list_contact_ids_api_v1_contacts_ids_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tag"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "name": "score",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Score"
+            }
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Priority"
+            }
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date From"
+            }
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Date To"
+            }
+          },
+          {
+            "name": "has_interactions",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Has Interactions"
+            }
+          },
+          {
+            "name": "interaction_days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 365,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Interaction Days"
+            }
+          },
+          {
+            "name": "has_birthday",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Has Birthday"
+            }
+          },
+          {
+            "name": "archived_only",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Archived Only"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_str__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/stats": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Contact Stats",
+        "description": "Return aggregate contact stats for the dashboard.",
+        "operationId": "contact_stats_api_v1_contacts_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ContactStatsData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/birthdays": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Get Upcoming Birthdays",
+        "description": "Return contacts with birthdays in the next 7 days.",
+        "operationId": "get_upcoming_birthdays_api_v1_contacts_birthdays_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/overdue": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Get Overdue Contacts",
+        "description": "Return high-priority contacts that have exceeded their follow-up threshold.\n\nOnly includes contacts with priority_level='high', at least one interaction,\nand not tagged '2nd tier'. Sorted by most overdue first.",
+        "operationId": "get_overdue_contacts_api_v1_contacts_overdue_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/tags": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "List Tags",
+        "description": "Return all unique tags used across the user's contacts (case-insensitive dedup).",
+        "operationId": "list_tags_api_v1_contacts_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_str__"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/import/csv": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Import Contacts Csv",
+        "operationId": "import_contacts_csv_api_v1_contacts_import_csv_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_import_contacts_csv_api_v1_contacts_import_csv_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_CsvImportResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/import/linkedin": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Import Linkedin Csv",
+        "description": "Import contacts from LinkedIn Connections.csv export.",
+        "operationId": "import_linkedin_csv_api_v1_contacts_import_linkedin_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_import_linkedin_csv_api_v1_contacts_import_linkedin_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_LinkedInImportResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/import/linkedin-messages": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Import Linkedin Messages",
+        "description": "Import LinkedIn messages.csv and create interactions matched to existing contacts.",
+        "operationId": "import_linkedin_messages_api_v1_contacts_import_linkedin_messages_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_import_linkedin_messages_api_v1_contacts_import_linkedin_messages_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_LinkedInMessagesImportResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/scores/recalculate": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Recalculate Scores",
+        "description": "Recalculate relationship scores for all contacts of the authenticated user.",
+        "operationId": "recalculate_scores_api_v1_contacts_scores_recalculate_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ScoresRecalculatedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/sync/google": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Sync Google Contacts",
+        "description": "Dispatch a background Google Contacts sync.\n\nReturns immediately. A notification is created when sync completes.",
+        "operationId": "sync_google_contacts_api_v1_contacts_sync_google_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SyncStartedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/sync/google-calendar": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Sync Google Calendar",
+        "description": "Dispatch a background Google Calendar sync.\n\nReturns immediately. A notification is created when sync completes.",
+        "operationId": "sync_google_calendar_api_v1_contacts_sync_google_calendar_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SyncStartedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/sync/gmail": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Sync Gmail",
+        "description": "Dispatch a background Gmail thread sync.\n\nReturns immediately. A notification is created when sync completes.",
+        "operationId": "sync_gmail_api_v1_contacts_sync_gmail_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SyncStartedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/sync/twitter": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Sync Twitter",
+        "description": "Dispatch a background Twitter sync (DMs + mentions + bios).\n\nReturns immediately. A notification is created when sync completes.",
+        "operationId": "sync_twitter_api_v1_contacts_sync_twitter_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SyncStartedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/{contact_id}/refresh-bios": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Refresh Contact Bios",
+        "description": "Check for bio updates on Twitter and Telegram for a single contact.\n\nRate-limited to once per 24 hours per contact (unless force=true).",
+        "operationId": "refresh_contact_bios_api_v1_contacts__contact_id__refresh_bios_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Bypass 24h rate limit (for manual refresh)",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Bypass 24h rate limit (for manual refresh)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_BioRefreshData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/refresh-avatar": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Refresh Contact Avatar",
+        "description": "Refresh a contact's avatar from Telegram or Twitter. Rate-limited to once per 24h.",
+        "operationId": "refresh_contact_avatar_api_v1_contacts__contact_id__refresh_avatar_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Bypass 24h rate limit (for manual refresh)",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Bypass 24h rate limit (for manual refresh)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_AvatarRefreshData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/sync-emails": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Sync Contact Emails",
+        "description": "Search Gmail for threads involving this contact's emails and save as interactions.\n\nRate-limited to once per hour per contact (unless force=true).",
+        "operationId": "sync_contact_emails_api_v1_contacts__contact_id__sync_emails_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Bypass 1h rate limit (for manual refresh)",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Bypass 1h rate limit (for manual refresh)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/sync-telegram": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Sync Contact Telegram",
+        "description": "Sync Telegram DMs for a single contact. Rate-limited to once per hour.",
+        "operationId": "sync_contact_telegram_api_v1_contacts__contact_id__sync_telegram_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Bypass 1h rate limit (for manual refresh)",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Bypass 1h rate limit (for manual refresh)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/sync-twitter": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Sync Contact Twitter",
+        "description": "Sync Twitter DMs for a single contact. Rate-limited to once per hour.",
+        "operationId": "sync_contact_twitter_api_v1_contacts__contact_id__sync_twitter_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Bypass 1h rate limit (for manual refresh)",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Bypass 1h rate limit (for manual refresh)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/reconcile-last-interaction": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Reconcile Last Interaction",
+        "description": "Reconcile last_interaction_at for all contacts from actual interaction data.\n\nFixes stale values caused by sync bugs where last_interaction_at wasn't\nupdated when interactions were created or skipped as duplicates.",
+        "operationId": "reconcile_last_interaction_api_v1_contacts_reconcile_last_interaction_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/map": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Contacts Map",
+        "operationId": "contacts_map_api_v1_contacts_map_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "bbox",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "minLng,minLat,maxLng,maxLat",
+              "title": "Bbox"
+            },
+            "description": "minLng,minLat,maxLng,maxLat"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 2000,
+              "minimum": 1,
+              "default": 500,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_ContactMapPin__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/bulk-update": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Bulk Update Contacts",
+        "description": "Bulk update tags and/or priority level for a set of contacts.",
+        "operationId": "bulk_update_contacts_api_v1_contacts_bulk_update_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkUpdateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/2nd-tier": {
+      "delete": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Delete 2Nd Tier Contacts",
+        "description": "Delete all contacts tagged as '2nd tier' for the current user.",
+        "operationId": "delete_2nd_tier_contacts_api_v1_contacts_2nd_tier_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/2nd-tier/count": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Count 2Nd Tier Contacts",
+        "description": "Count contacts tagged as '2nd tier' for the current user.",
+        "operationId": "count_2nd_tier_contacts_api_v1_contacts_2nd_tier_count_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/{contact_id}": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Get Contact",
+        "operationId": "get_contact_api_v1_contacts__contact_id__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ContactResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Update Contact",
+        "operationId": "update_contact_api_v1_contacts__contact_id__put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContactUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ContactResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Delete Contact",
+        "operationId": "delete_contact_api_v1_contacts__contact_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_DeletedData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/activity": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Get Contact Activity",
+        "description": "Return activity score breakdown and monthly interaction trend for a contact.",
+        "operationId": "get_contact_activity_api_v1_contacts__contact_id__activity_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/related": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Get Related Contacts",
+        "description": "Return up to 5 contacts related to the given contact by org, company, or shared tags.",
+        "operationId": "get_related_contacts_api_v1_contacts__contact_id__related_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/enrich": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Enrich Contact",
+        "description": "Enrich a contact using the Apollo People Enrichment API.\n\nOnly fills in fields that are currently empty/null on the contact.",
+        "operationId": "enrich_contact_api_v1_contacts__contact_id__enrich_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_EnrichData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/extract-bio": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Extract Bio",
+        "description": "Extract structured data from contact bios using AI.\n\nParses twitter_bio, telegram_bio, linkedin_bio/headline and the contact's\nname fields through Haiku to extract title, company, website, and\nnormalize name fields (e.g. \"Anders | LoopFi\" -> first: Anders, company: LoopFi).\nAlso updates the linked Organization record with extracted company details.",
+        "operationId": "extract_bio_api_v1_contacts__contact_id__extract_bio_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_EnrichData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/promote": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Promote Contact",
+        "description": "Remove '2nd Tier' tag from a contact, promoting it to 1st Tier.",
+        "operationId": "promote_contact_api_v1_contacts__contact_id__promote_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/duplicates": {
+      "get": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Find Contact Duplicates",
+        "description": "Find possible duplicates for a specific contact.",
+        "operationId": "find_contact_duplicates_api_v1_contacts__contact_id__duplicates_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_DuplicateContactData__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/dismiss-duplicate/{other_id}": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Dismiss Duplicate",
+        "description": "Dismiss a duplicate pair by creating a rejected IdentityMatch.",
+        "operationId": "dismiss_duplicate_api_v1_contacts__contact_id__dismiss_duplicate__other_id__post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "other_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Other Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/merge/{other_id}": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Merge Contact Pair",
+        "description": "Merge other_id into contact_id. Returns the surviving contact.",
+        "operationId": "merge_contact_pair_api_v1_contacts__contact_id__merge__other_id__post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "other_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Other Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_MergedContactData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/send-message": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Send Message",
+        "description": "Send a message to a contact via the specified channel.\n\nCurrently supports Telegram. Creates an Interaction record on success.",
+        "operationId": "send_message_api_v1_contacts__contact_id__send_message_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendMessageBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SendMessageData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/compose": {
+      "post": {
+        "tags": [
+          "contacts"
+        ],
+        "summary": "Compose Message",
+        "description": "Generate an AI-drafted reach-out message for a contact (no suggestion required).",
+        "operationId": "compose_message_api_v1_contacts__contact_id__compose_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ComposeBody"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/interactions": {
+      "get": {
+        "tags": [
+          "interactions"
+        ],
+        "summary": "List Interactions",
+        "operationId": "list_interactions_api_v1_contacts__contact_id__interactions_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_InteractionResponse__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "interactions"
+        ],
+        "summary": "Create Interaction",
+        "operationId": "create_interaction_api_v1_contacts__contact_id__interactions_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InteractionCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_InteractionResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/contacts/{contact_id}/interactions/{interaction_id}": {
+      "patch": {
+        "tags": [
+          "interactions"
+        ],
+        "summary": "Update Interaction",
+        "description": "Update a manual note's content. Only platform='manual' interactions are editable.",
+        "operationId": "update_interaction_api_v1_contacts__contact_id__interactions__interaction_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "interaction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Interaction Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InteractionUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_InteractionResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "interactions"
+        ],
+        "summary": "Delete Interaction",
+        "description": "Delete a manual note. Only platform='manual' interactions can be deleted.",
+        "operationId": "delete_interaction_api_v1_contacts__contact_id__interactions__interaction_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "interaction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Interaction Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/register": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Register",
+        "operationId": "register_api_v1_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_UserResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login",
+        "operationId": "login_api_v1_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_api_v1_auth_login_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TokenData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Me",
+        "operationId": "me_api_v1_auth_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_UserWithAccountsData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Update Profile",
+        "description": "Update the authenticated user's profile.",
+        "operationId": "update_profile_api_v1_auth_me_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Delete Account",
+        "description": "Permanently delete the authenticated user's account and all data.",
+        "operationId": "delete_account_api_v1_auth_me_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/google/accounts": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "List Google Accounts",
+        "operationId": "list_google_accounts_api_v1_auth_google_accounts_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_GoogleAccountData__"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/google/accounts/{account_id}": {
+      "delete": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Remove Google Account",
+        "operationId": "remove_google_account_api_v1_auth_google_accounts__account_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Account Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_DeletedData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/google/url": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Google Oauth Url",
+        "description": "Return the Google OAuth consent screen URL.",
+        "operationId": "google_oauth_url_api_v1_auth_google_url_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_OAuthUrlData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/google/callback": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Google Callback",
+        "description": "Exchange a Google authorization code for a JWT access token.\n\n- Validates the ``state`` parameter against the server-side nonce store\n  to prevent CSRF attacks.\n- If the state was created by an authenticated user (connect-account flow),\n  verifies that the current authenticated user matches the stored user_id.\n- If a user with the returned email already exists, update their refresh token.\n- Otherwise create a new account from the Google profile information.",
+        "operationId": "google_callback_api_v1_auth_google_callback_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GoogleCallbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TokenData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/change-password": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Change Password",
+        "description": "Change the authenticated user's password.",
+        "operationId": "change_password_api_v1_auth_change_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PasswordChange"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/suggestions": {
+      "get": {
+        "tags": [
+          "suggestions"
+        ],
+        "summary": "List Suggestions",
+        "description": "List pending follow-up suggestions for the current user, with contact info.",
+        "operationId": "list_suggestions_api_v1_suggestions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_dict__"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/suggestions/digest": {
+      "get": {
+        "tags": [
+          "suggestions"
+        ],
+        "summary": "Get Digest",
+        "description": "Return the weekly digest data for the current user.",
+        "operationId": "get_digest_api_v1_suggestions_digest_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_dict__"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/suggestions/{suggestion_id}": {
+      "put": {
+        "tags": [
+          "suggestions"
+        ],
+        "summary": "Update Suggestion",
+        "description": "Update suggestion status.\n\n- **sent**: marks sent, updates contact.last_followup_at\n- **snoozed**: accepts snooze_until or scheduled_for datetime\n- **dismissed**: marks dismissed",
+        "operationId": "update_suggestion_api_v1_suggestions__suggestion_id__put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "suggestion_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Suggestion Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SuggestionUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_FollowUpResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/suggestions/generate": {
+      "post": {
+        "tags": [
+          "suggestions"
+        ],
+        "summary": "Generate Suggestions",
+        "description": "Manually trigger suggestion generation for the current user.\n\nIf no contacts have been scored yet, runs score recalculation first\nso the engine has data to work with.",
+        "operationId": "generate_suggestions_api_v1_suggestions_generate_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_FollowUpResponse__"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/suggestions/{suggestion_id}/regenerate": {
+      "post": {
+        "tags": [
+          "suggestions"
+        ],
+        "summary": "Regenerate Suggestion",
+        "description": "Re-generate the AI-drafted message for an existing suggestion.",
+        "operationId": "regenerate_suggestion_api_v1_suggestions__suggestion_id__regenerate_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "suggestion_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Suggestion Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/RegenerateBody"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_RegenerateResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/telegram/connect": {
+      "post": {
+        "tags": [
+          "telegram"
+        ],
+        "summary": "Telegram Connect",
+        "description": "Initiate Telegram login by sending an OTP to *phone*.\n\nThe returned ``phone_code_hash`` must be passed back to\n``POST /api/v1/auth/telegram/verify``.",
+        "operationId": "telegram_connect_api_v1_auth_telegram_connect_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TelegramConnectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TelegramConnectData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/telegram/verify": {
+      "post": {
+        "tags": [
+          "telegram"
+        ],
+        "summary": "Telegram Verify",
+        "description": "Complete Telegram sign-in with the OTP code.\n\nOn success the session is stored and the user is connected to Telegram.",
+        "operationId": "telegram_verify_api_v1_auth_telegram_verify_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TelegramVerifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TelegramVerifyData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/telegram/verify-2fa": {
+      "post": {
+        "tags": [
+          "telegram"
+        ],
+        "summary": "Telegram Verify 2Fa",
+        "description": "Complete Telegram sign-in for accounts with two-step verification enabled.\n\nMust be called after ``/verify`` returns ``requires_2fa: true``.",
+        "operationId": "telegram_verify_2fa_api_v1_auth_telegram_verify_2fa_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Telegram2FARequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TelegramConnectedData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/sync/telegram": {
+      "post": {
+        "tags": [
+          "telegram"
+        ],
+        "summary": "Sync Telegram",
+        "description": "Dispatch a background Telegram sync for the authenticated user.\n\nReturns immediately with status \"started\". A notification is created\nwhen the sync completes.",
+        "operationId": "sync_telegram_api_v1_contacts_sync_telegram_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SyncStartedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/telegram/disconnect": {
+      "delete": {
+        "tags": [
+          "telegram"
+        ],
+        "summary": "Disconnect Telegram",
+        "description": "Clear Telegram session and related data for the authenticated user.",
+        "operationId": "disconnect_telegram_api_v1_auth_telegram_disconnect_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/telegram/reset-session": {
+      "post": {
+        "tags": [
+          "telegram"
+        ],
+        "summary": "Reset Telegram Session",
+        "description": "Clear only the Telegram session (keeps username for re-connect).",
+        "operationId": "reset_telegram_session_api_v1_auth_telegram_reset_session_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/telegram/sync-progress": {
+      "get": {
+        "tags": [
+          "telegram"
+        ],
+        "summary": "Get Sync Progress",
+        "description": "Return current Telegram sync progress for the authenticated user.\n\nReturns ``active: false`` when no sync is running or recently completed.",
+        "operationId": "get_sync_progress_api_v1_telegram_sync_progress_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Sync Progress Api V1 Telegram Sync Progress Get"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/{contact_id}/telegram/common-groups": {
+      "get": {
+        "tags": [
+          "telegram"
+        ],
+        "summary": "Get Common Groups",
+        "description": "Return Telegram groups in common with a contact.\n\nResults are cached on the contact. Auto-refreshes on contact detail visit\nif not already cached. Use force=true for manual refresh.",
+        "operationId": "get_common_groups_api_v1_contacts__contact_id__telegram_common_groups_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "contact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Contact Id"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Bypass cache and re-fetch from Telegram",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Bypass cache and re-fetch from Telegram"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_dict__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/identity/matches": {
+      "get": {
+        "tags": [
+          "identity"
+        ],
+        "summary": "List Pending Matches",
+        "description": "List all pending identity matches for the authenticated user's contacts.",
+        "operationId": "list_pending_matches_api_v1_identity_matches_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_IdentityMatchData__"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/identity/matches/{match_id}/merge": {
+      "post": {
+        "tags": [
+          "identity"
+        ],
+        "summary": "Confirm Merge",
+        "description": "Confirm and execute a pending identity match merge.",
+        "operationId": "confirm_merge_api_v1_identity_matches__match_id__merge_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "match_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Match Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_IdentityMatchData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/identity/matches/{match_id}/reject": {
+      "post": {
+        "tags": [
+          "identity"
+        ],
+        "summary": "Reject Match",
+        "description": "Reject a pending identity match (mark as rejected).",
+        "operationId": "reject_match_api_v1_identity_matches__match_id__reject_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "match_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Match Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_IdentityMatchData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/identity/scan": {
+      "post": {
+        "tags": [
+          "identity"
+        ],
+        "summary": "Trigger Scan",
+        "description": "Trigger a full identity resolution scan for the current user's contacts.",
+        "operationId": "trigger_scan_api_v1_identity_scan_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ScanResultData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/twitter/url": {
+      "get": {
+        "tags": [
+          "twitter-auth"
+        ],
+        "summary": "Get Twitter Auth Url",
+        "description": "Return a Twitter OAuth 2.0 authorization URL.",
+        "operationId": "get_twitter_auth_url_api_v1_auth_twitter_url_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TwitterAuthUrlData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/twitter/callback": {
+      "post": {
+        "tags": [
+          "twitter-auth"
+        ],
+        "summary": "Twitter Callback",
+        "description": "Exchange Twitter authorization code for tokens and store on user.",
+        "operationId": "twitter_callback_api_v1_auth_twitter_callback_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TwitterCallbackRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TwitterConnectedData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/twitter/disconnect": {
+      "delete": {
+        "tags": [
+          "twitter-auth"
+        ],
+        "summary": "Disconnect Twitter",
+        "description": "Clear Twitter OAuth tokens and related data for the authenticated user.",
+        "operationId": "disconnect_twitter_api_v1_auth_twitter_disconnect_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/notifications": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "List Notifications",
+        "operationId": "list_notifications_api_v1_notifications_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "link",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Link"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notifications/unread-count": {
+      "get": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Unread Count",
+        "operationId": "unread_count_api_v1_notifications_unread_count_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_UnreadCountData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/notifications/read-all": {
+      "put": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Mark All Read",
+        "operationId": "mark_all_read_api_v1_notifications_read_all_put",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_MarkedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/notifications/{notification_id}/read": {
+      "put": {
+        "tags": [
+          "notifications"
+        ],
+        "summary": "Mark Read",
+        "operationId": "mark_read_api_v1_notifications__notification_id__read_put",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "notification_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Notification Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_NotificationReadData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/organizations": {
+      "post": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Create Organization",
+        "operationId": "create_organization_api_v1_organizations_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_OrganizationResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "List Organizations",
+        "description": "Return organizations with stats from materialized view.\n\nExcludes orgs that have zero active (non-archived) contacts.",
+        "operationId": "list_organizations_api_v1_organizations_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Page Size"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by name (case-insensitive)",
+              "title": "Search"
+            },
+            "description": "Filter by name (case-insensitive)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_OrganizationResponse__"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/merge": {
+      "post": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Merge Organizations",
+        "description": "Merge source organizations into the target organization.\n\nMoves all contacts from source orgs to target, then deletes sources.",
+        "operationId": "merge_organizations_api_v1_organizations_merge_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MergeOrganizationsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_MergeOrganizationsResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/backfill-logos": {
+      "post": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Backfill Org Logos Endpoint",
+        "description": "Dispatch a background task to backfill logos for orgs that have none.\n\nReturns immediately; the actual work happens asynchronously in Celery.",
+        "operationId": "backfill_org_logos_endpoint_api_v1_organizations_backfill_logos_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/organizations/{org_id}": {
+      "get": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Get Organization",
+        "operationId": "get_organization_api_v1_organizations__org_id__get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Org Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_OrganizationResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Update Organization",
+        "operationId": "update_organization_api_v1_organizations__org_id__patch",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Org Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_OrganizationResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Delete Organization",
+        "operationId": "delete_organization_api_v1_organizations__org_id__delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Org Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/{org_id}/stats": {
+      "get": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Get Organization Stats",
+        "operationId": "get_organization_stats_api_v1_organizations__org_id__stats_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Org Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_OrgStatsResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/{org_id}/refresh-logo": {
+      "post": {
+        "tags": [
+          "organizations"
+        ],
+        "summary": "Refresh Org Logo",
+        "description": "Re-download the organization favicon/logo. Rate-limited to once per hour per org.",
+        "operationId": "refresh_org_logo_api_v1_organizations__org_id__refresh_logo_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "org_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Org Id"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Bypass 1h rate limit",
+              "default": false,
+              "title": "Force"
+            },
+            "description": "Bypass 1h rate limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/settings/priority": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get Priority",
+        "operationId": "get_priority_api_v1_settings_priority_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_PrioritySettingsData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Update Priority",
+        "operationId": "update_priority_api_v1_settings_priority_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrioritySettingsInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_PrioritySettingsData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/suggestions": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get Suggestion Prefs",
+        "operationId": "get_suggestion_prefs_api_v1_settings_suggestions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SuggestionPrefsData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Update Suggestion Prefs",
+        "operationId": "update_suggestion_prefs_api_v1_settings_suggestions_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SuggestionPrefsInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SuggestionPrefsData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/sync": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get Sync Settings",
+        "operationId": "get_sync_settings_api_v1_settings_sync_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SyncSettingsData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Update Sync Settings",
+        "operationId": "update_sync_settings_api_v1_settings_sync_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncSettingsInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SyncSettingsData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/telegram": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get Telegram Settings",
+        "operationId": "get_telegram_settings_api_v1_settings_telegram_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TelegramSettingsData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Update Telegram Settings",
+        "operationId": "update_telegram_settings_api_v1_settings_telegram_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TelegramSettingsInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TelegramSettingsData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/settings/mcp-key": {
+      "get": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get Mcp Key Status",
+        "operationId": "get_mcp_key_status_api_v1_settings_mcp_key_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_McpKeyStatusData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Generate Mcp Key",
+        "operationId": "generate_mcp_key_api_v1_settings_mcp_key_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_McpKeyData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "settings"
+        ],
+        "summary": "Revoke Mcp Key",
+        "operationId": "revoke_mcp_key_api_v1_settings_mcp_key_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_McpKeyRevokedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/linkedin/push": {
+      "post": {
+        "tags": [
+          "linkedin"
+        ],
+        "summary": "Push Linkedin Data",
+        "description": "Receive profile and message data from the LinkedIn Chrome Extension.",
+        "operationId": "push_linkedin_data_api_v1_linkedin_push_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LinkedInPushRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_LinkedInPushResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/activity/recent": {
+      "get": {
+        "tags": [
+          "activity"
+        ],
+        "summary": "Get Recent Activity",
+        "description": "Return a unified activity feed of recent interactions across all contacts.",
+        "operationId": "get_recent_activity_api_v1_activity_recent_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/extension/pair": {
+      "post": {
+        "tags": [
+          "extension"
+        ],
+        "summary": "Create Pairing",
+        "description": "Authenticated user submits a pairing code from the extension popup.\n\nCreates an ExtensionPairing record with a scoped JWT, and marks\nthe user's linkedin_extension_paired_at timestamp.",
+        "operationId": "create_pairing_api_v1_extension_pair_post",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PairRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "extension"
+        ],
+        "summary": "Poll Pairing",
+        "description": "Unauthenticated endpoint polled by the extension after the user enters their code.\n\nReturns the scoped JWT when the pairing is ready.\nIncrements attempt counter to prevent brute-force enumeration.",
+        "operationId": "poll_pairing_api_v1_extension_pair_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_PairTokenResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "extension"
+        ],
+        "summary": "Disconnect Extension",
+        "description": "Authenticated endpoint to disconnect the extension.\n\nDeletes all pairing records for the user and clears linkedin_extension_paired_at.",
+        "operationId": "disconnect_extension_api_v1_extension_pair_delete",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/sync-history": {
+      "get": {
+        "tags": [
+          "sync-history"
+        ],
+        "summary": "List Sync Events",
+        "description": "List sync events for the current user, most recent first.",
+        "operationId": "list_sync_events_api_v1_sync_history_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/sync-history/stats": {
+      "get": {
+        "tags": [
+          "sync-history"
+        ],
+        "summary": "Sync Stats",
+        "description": "Quick stats: total syncs, success rate, last sync per platform.",
+        "operationId": "sync_stats_api_v1_sync_history_stats_get",
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "platform",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Platform"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/whatsapp/connect": {
+      "post": {
+        "tags": [
+          "whatsapp"
+        ],
+        "summary": "Whatsapp Connect",
+        "description": "Start a WhatsApp session (or resume one) and return QR code if needed.",
+        "operationId": "whatsapp_connect_api_v1_auth_whatsapp_connect_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_WhatsAppSessionData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/whatsapp/qr": {
+      "get": {
+        "tags": [
+          "whatsapp"
+        ],
+        "summary": "Whatsapp Get Qr",
+        "description": "Return the current QR code for a pending WhatsApp session.",
+        "operationId": "whatsapp_get_qr_api_v1_auth_whatsapp_qr_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_WhatsAppSessionData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/whatsapp/status": {
+      "get": {
+        "tags": [
+          "whatsapp"
+        ],
+        "summary": "Whatsapp Get Status",
+        "description": "Return the current WhatsApp session status.",
+        "operationId": "whatsapp_get_status_api_v1_auth_whatsapp_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_WhatsAppStatusData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/contacts/sync/whatsapp": {
+      "post": {
+        "tags": [
+          "whatsapp"
+        ],
+        "summary": "Sync Whatsapp",
+        "description": "Dispatch a background WhatsApp backfill sync for the authenticated user.",
+        "operationId": "sync_whatsapp_api_v1_contacts_sync_whatsapp_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SyncStartedData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/auth/whatsapp/disconnect": {
+      "delete": {
+        "tags": [
+          "whatsapp"
+        ],
+        "summary": "Whatsapp Disconnect",
+        "description": "Disconnect WhatsApp: destroy the sidecar session and clear user fields.",
+        "operationId": "whatsapp_disconnect_api_v1_auth_whatsapp_disconnect_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/webhooks/whatsapp": {
+      "post": {
+        "tags": [
+          "whatsapp"
+        ],
+        "summary": "Whatsapp Webhook",
+        "description": "Receive events from the whatsapp-sidecar service.",
+        "operationId": "whatsapp_webhook_api_v1_webhooks_whatsapp_post",
+        "parameters": [
+          {
+            "name": "x-webhook-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Webhook-Signature"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_dict_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/meta/push": {
+      "post": {
+        "tags": [
+          "meta"
+        ],
+        "summary": "Push Meta Data",
+        "description": "Receive profile and message data from the Meta Chrome Extension.",
+        "operationId": "push_meta_data_api_v1_meta_push_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetaPushRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_MetaPushResult_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/integrations/twitter/cookies": {
+      "get": {
+        "tags": [
+          "twitter-bird-cookies"
+        ],
+        "summary": "Get Status",
+        "operationId": "get_status_api_v1_integrations_twitter_cookies_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TwitterBirdStatusData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "twitter-bird-cookies"
+        ],
+        "summary": "Push Cookies",
+        "operationId": "push_cookies_api_v1_integrations_twitter_cookies_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CookiesInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TwitterBirdStatusData_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "twitter-bird-cookies"
+        ],
+        "summary": "Clear Cookies",
+        "operationId": "clear_cookies_api_v1_integrations_twitter_cookies_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_TwitterBirdStatusData_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/map/config": {
+      "get": {
+        "tags": [
+          "map"
+        ],
+        "summary": "Map Config",
+        "operationId": "map_config_api_v1_map_config_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_MapConfig_"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/errors": {
+      "post": {
+        "tags": [
+          "errors"
+        ],
+        "summary": "Report Frontend Error",
+        "description": "Receive client-side errors and log them in the structured backend log.",
+        "operationId": "report_frontend_error_api_v1_errors_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FrontendErrorReport"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Report Frontend Error Api V1 Errors Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/health": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Health Check",
+        "operationId": "health_check_api_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Health Check Api Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApplyTagsBody": {
+        "properties": {
+          "contact_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contact Ids"
+          }
+        },
+        "type": "object",
+        "title": "ApplyTagsBody"
+      },
+      "ApplyTagsResult": {
+        "properties": {
+          "tagged_count": {
+            "type": "integer",
+            "title": "Tagged Count"
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tagged_count"
+        ],
+        "title": "ApplyTagsResult"
+      },
+      "AutoTagResult": {
+        "properties": {
+          "tags_added": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags Added"
+          },
+          "all_tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "All Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "tags_added",
+          "all_tags"
+        ],
+        "title": "AutoTagResult"
+      },
+      "AvatarRefreshData": {
+        "properties": {
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "changed": {
+            "type": "boolean",
+            "title": "Changed",
+            "default": false
+          },
+          "skipped": {
+            "type": "boolean",
+            "title": "Skipped",
+            "default": false
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "title": "AvatarRefreshData"
+      },
+      "BackfillItem": {
+        "properties": {
+          "contact_id": {
+            "type": "string",
+            "title": "Contact Id"
+          },
+          "linkedin_profile_id": {
+            "type": "string",
+            "title": "Linkedin Profile Id"
+          },
+          "linkedin_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "contact_id",
+          "linkedin_profile_id"
+        ],
+        "title": "BackfillItem"
+      },
+      "BioRefreshData": {
+        "properties": {
+          "twitter_bio_changed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Bio Changed"
+          },
+          "telegram_bio_changed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Bio Changed"
+          },
+          "skipped": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Skipped"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "title": "BioRefreshData"
+      },
+      "Body_import_contacts_csv_api_v1_contacts_import_csv_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_import_contacts_csv_api_v1_contacts_import_csv_post"
+      },
+      "Body_import_linkedin_csv_api_v1_contacts_import_linkedin_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_import_linkedin_csv_api_v1_contacts_import_linkedin_post"
+      },
+      "Body_import_linkedin_messages_api_v1_contacts_import_linkedin_messages_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_import_linkedin_messages_api_v1_contacts_import_linkedin_messages_post"
+      },
+      "Body_login_api_v1_auth_login_post": {
+        "properties": {
+          "grant_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "password"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": ""
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Secret"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_login_api_v1_auth_login_post"
+      },
+      "BulkUpdateBody": {
+        "properties": {
+          "contact_ids": {
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": "array",
+            "maxItems": 500,
+            "title": "Contact Ids"
+          },
+          "add_tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "maxItems": 50
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Add Tags"
+          },
+          "remove_tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "maxItems": 50
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remove Tags"
+          },
+          "priority_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority Level"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          }
+        },
+        "type": "object",
+        "required": [
+          "contact_ids"
+        ],
+        "title": "BulkUpdateBody"
+      },
+      "ComposeBody": {
+        "properties": {
+          "channel": {
+            "type": "string",
+            "title": "Channel",
+            "default": "email"
+          }
+        },
+        "type": "object",
+        "title": "ComposeBody"
+      },
+      "ContactCreate": {
+        "properties": {
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "given_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Given Name"
+          },
+          "family_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Family Name"
+          },
+          "emails": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Emails",
+            "default": []
+          },
+          "phones": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Phones",
+            "default": []
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "twitter_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Handle"
+          },
+          "twitter_bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Bio"
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "telegram_bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Bio"
+          },
+          "whatsapp_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Phone"
+          },
+          "whatsapp_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Name"
+          },
+          "whatsapp_about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp About"
+          },
+          "whatsapp_avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Avatar Url"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "linkedin_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Url"
+          },
+          "linkedin_profile_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Profile Id"
+          },
+          "linkedin_headline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Headline"
+          },
+          "linkedin_bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Bio"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "birthday": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Birthday"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "default": []
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "priority_level": {
+            "type": "string",
+            "title": "Priority Level",
+            "default": "medium"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "title": "ContactCreate"
+      },
+      "ContactListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ContactResponse"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "ContactListResponse"
+      },
+      "ContactMapPin": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "latitude": {
+            "type": "number",
+            "title": "Latitude"
+          },
+          "longitude": {
+            "type": "number",
+            "title": "Longitude"
+          },
+          "relationship_score": {
+            "type": "integer",
+            "title": "Relationship Score"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "full_name",
+          "avatar_url",
+          "latitude",
+          "longitude",
+          "relationship_score"
+        ],
+        "title": "ContactMapPin"
+      },
+      "ContactResponse": {
+        "properties": {
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "given_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Given Name"
+          },
+          "family_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Family Name"
+          },
+          "emails": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Emails",
+            "default": []
+          },
+          "phones": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Phones",
+            "default": []
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "twitter_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Handle"
+          },
+          "twitter_bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Bio"
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "telegram_bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Bio"
+          },
+          "whatsapp_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Phone"
+          },
+          "whatsapp_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Name"
+          },
+          "whatsapp_about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp About"
+          },
+          "whatsapp_avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Avatar Url"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "linkedin_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Url"
+          },
+          "linkedin_profile_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Profile Id"
+          },
+          "linkedin_headline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Headline"
+          },
+          "linkedin_bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Bio"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "birthday": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Birthday"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "default": []
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "priority_level": {
+            "type": "string",
+            "title": "Priority Level",
+            "default": "medium"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "User Id"
+          },
+          "organization_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization Id"
+          },
+          "telegram_last_seen_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Last Seen At"
+          },
+          "relationship_score": {
+            "type": "integer",
+            "title": "Relationship Score"
+          },
+          "interaction_count": {
+            "type": "integer",
+            "title": "Interaction Count",
+            "default": 0
+          },
+          "last_interaction_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Interaction At"
+          },
+          "last_followup_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Followup At"
+          },
+          "user_edited_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "User Edited Fields",
+            "default": []
+          },
+          "bcc_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bcc Hash"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Longitude"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "user_id",
+          "relationship_score",
+          "created_at"
+        ],
+        "title": "ContactResponse"
+      },
+      "ContactStatsData": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "strong": {
+            "type": "integer",
+            "title": "Strong"
+          },
+          "active": {
+            "type": "integer",
+            "title": "Active"
+          },
+          "dormant": {
+            "type": "integer",
+            "title": "Dormant"
+          },
+          "interactions_this_week": {
+            "type": "integer",
+            "title": "Interactions This Week",
+            "default": 0
+          },
+          "interactions_last_week": {
+            "type": "integer",
+            "title": "Interactions Last Week",
+            "default": 0
+          },
+          "active_last_week": {
+            "type": "integer",
+            "title": "Active Last Week",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "strong",
+          "active",
+          "dormant"
+        ],
+        "title": "ContactStatsData"
+      },
+      "ContactSummaryData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "given_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Given Name"
+          },
+          "family_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Family Name"
+          },
+          "emails": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Emails",
+            "default": []
+          },
+          "phones": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Phones",
+            "default": []
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "twitter_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Handle"
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "linkedin_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Url"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "default": []
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "ContactSummaryData"
+      },
+      "ContactUpdate": {
+        "properties": {
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "given_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Given Name"
+          },
+          "family_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Family Name"
+          },
+          "emails": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Emails"
+          },
+          "phones": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phones"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "twitter_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Handle"
+          },
+          "twitter_bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Bio"
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "whatsapp_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Phone"
+          },
+          "whatsapp_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Name"
+          },
+          "whatsapp_about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp About"
+          },
+          "whatsapp_avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Avatar Url"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "linkedin_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Url"
+          },
+          "linkedin_profile_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Profile Id"
+          },
+          "linkedin_headline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Headline"
+          },
+          "linkedin_bio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Bio"
+          },
+          "birthday": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Birthday"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "priority_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority Level"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "organization_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization Id"
+          }
+        },
+        "type": "object",
+        "title": "ContactUpdate"
+      },
+      "CookiesInput": {
+        "properties": {
+          "auth_token": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Auth Token"
+          },
+          "ct0": {
+            "type": "string",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Ct0"
+          }
+        },
+        "type": "object",
+        "required": [
+          "auth_token",
+          "ct0"
+        ],
+        "title": "CookiesInput"
+      },
+      "CsvImportResult": {
+        "properties": {
+          "created": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Created"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Errors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "created",
+          "errors"
+        ],
+        "title": "CsvImportResult"
+      },
+      "DeletedData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "deleted"
+        ],
+        "title": "DeletedData"
+      },
+      "DuplicateContactData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "given_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Given Name"
+          },
+          "family_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Family Name"
+          },
+          "emails": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Emails",
+            "default": []
+          },
+          "phones": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Phones",
+            "default": []
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "twitter_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Handle"
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "score": {
+            "type": "number",
+            "title": "Score"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "score"
+        ],
+        "title": "DuplicateContactData"
+      },
+      "EnrichData": {
+        "properties": {
+          "fields_updated": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Fields Updated"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "default": "apollo"
+          }
+        },
+        "type": "object",
+        "required": [
+          "fields_updated"
+        ],
+        "title": "EnrichData"
+      },
+      "Envelope": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope"
+      },
+      "Envelope_ApplyTagsResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ApplyTagsResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[ApplyTagsResult]"
+      },
+      "Envelope_AutoTagResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AutoTagResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[AutoTagResult]"
+      },
+      "Envelope_AvatarRefreshData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AvatarRefreshData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[AvatarRefreshData]"
+      },
+      "Envelope_BioRefreshData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BioRefreshData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[BioRefreshData]"
+      },
+      "Envelope_ContactResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContactResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[ContactResponse]"
+      },
+      "Envelope_ContactStatsData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContactStatsData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[ContactStatsData]"
+      },
+      "Envelope_CsvImportResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CsvImportResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[CsvImportResult]"
+      },
+      "Envelope_DeletedData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DeletedData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[DeletedData]"
+      },
+      "Envelope_EnrichData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EnrichData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[EnrichData]"
+      },
+      "Envelope_FollowUpResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FollowUpResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[FollowUpResponse]"
+      },
+      "Envelope_IdentityMatchData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IdentityMatchData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[IdentityMatchData]"
+      },
+      "Envelope_InteractionResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InteractionResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[InteractionResponse]"
+      },
+      "Envelope_LinkedInImportResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LinkedInImportResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[LinkedInImportResult]"
+      },
+      "Envelope_LinkedInMessagesImportResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LinkedInMessagesImportResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[LinkedInMessagesImportResult]"
+      },
+      "Envelope_LinkedInPushResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LinkedInPushResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[LinkedInPushResult]"
+      },
+      "Envelope_MapConfig_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MapConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[MapConfig]"
+      },
+      "Envelope_MarkedData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MarkedData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[MarkedData]"
+      },
+      "Envelope_McpKeyData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/McpKeyData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[McpKeyData]"
+      },
+      "Envelope_McpKeyRevokedData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/McpKeyRevokedData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[McpKeyRevokedData]"
+      },
+      "Envelope_McpKeyStatusData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/McpKeyStatusData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[McpKeyStatusData]"
+      },
+      "Envelope_MergeOrganizationsResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MergeOrganizationsResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[MergeOrganizationsResult]"
+      },
+      "Envelope_MergedContactData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MergedContactData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[MergedContactData]"
+      },
+      "Envelope_MetaPushResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MetaPushResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[MetaPushResult]"
+      },
+      "Envelope_NotificationReadData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NotificationReadData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[NotificationReadData]"
+      },
+      "Envelope_OAuthUrlData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OAuthUrlData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[OAuthUrlData]"
+      },
+      "Envelope_OrgStatsResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OrgStatsResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[OrgStatsResponse]"
+      },
+      "Envelope_OrganizationResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OrganizationResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[OrganizationResponse]"
+      },
+      "Envelope_PairTokenResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PairTokenResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[PairTokenResponse]"
+      },
+      "Envelope_PrioritySettingsData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PrioritySettingsData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[PrioritySettingsData]"
+      },
+      "Envelope_RegenerateResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RegenerateResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[RegenerateResult]"
+      },
+      "Envelope_ScanResultData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScanResultData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[ScanResultData]"
+      },
+      "Envelope_ScoresRecalculatedData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScoresRecalculatedData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[ScoresRecalculatedData]"
+      },
+      "Envelope_SendMessageData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SendMessageData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[SendMessageData]"
+      },
+      "Envelope_SuggestionPrefsData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SuggestionPrefsData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[SuggestionPrefsData]"
+      },
+      "Envelope_SyncSettingsData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SyncSettingsData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[SyncSettingsData]"
+      },
+      "Envelope_SyncStartedData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SyncStartedData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[SyncStartedData]"
+      },
+      "Envelope_TaxonomyResult_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TaxonomyResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TaxonomyResult]"
+      },
+      "Envelope_TelegramConnectData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TelegramConnectData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TelegramConnectData]"
+      },
+      "Envelope_TelegramConnectedData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TelegramConnectedData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TelegramConnectedData]"
+      },
+      "Envelope_TelegramSettingsData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TelegramSettingsData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TelegramSettingsData]"
+      },
+      "Envelope_TelegramVerifyData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TelegramVerifyData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TelegramVerifyData]"
+      },
+      "Envelope_TokenData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TokenData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TokenData]"
+      },
+      "Envelope_TwitterAuthUrlData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TwitterAuthUrlData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TwitterAuthUrlData]"
+      },
+      "Envelope_TwitterBirdStatusData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TwitterBirdStatusData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TwitterBirdStatusData]"
+      },
+      "Envelope_TwitterConnectedData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TwitterConnectedData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[TwitterConnectedData]"
+      },
+      "Envelope_UnreadCountData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UnreadCountData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[UnreadCountData]"
+      },
+      "Envelope_UserResponse_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UserResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[UserResponse]"
+      },
+      "Envelope_UserWithAccountsData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UserWithAccountsData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[UserWithAccountsData]"
+      },
+      "Envelope_WhatsAppSessionData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WhatsAppSessionData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[WhatsAppSessionData]"
+      },
+      "Envelope_WhatsAppStatusData_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WhatsAppStatusData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[WhatsAppStatusData]"
+      },
+      "Envelope_dict_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[dict]"
+      },
+      "Envelope_list_": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list]"
+      },
+      "Envelope_list_ContactMapPin__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ContactMapPin"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[ContactMapPin]]"
+      },
+      "Envelope_list_DuplicateContactData__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DuplicateContactData"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[DuplicateContactData]]"
+      },
+      "Envelope_list_FollowUpResponse__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/FollowUpResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[FollowUpResponse]]"
+      },
+      "Envelope_list_GoogleAccountData__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/GoogleAccountData"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[GoogleAccountData]]"
+      },
+      "Envelope_list_IdentityMatchData__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/IdentityMatchData"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[IdentityMatchData]]"
+      },
+      "Envelope_list_InteractionResponse__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/InteractionResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[InteractionResponse]]"
+      },
+      "Envelope_list_OrganizationResponse__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[OrganizationResponse]]"
+      },
+      "Envelope_list_dict__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[dict]]"
+      },
+      "Envelope_list_str__": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          }
+        },
+        "type": "object",
+        "title": "Envelope[list[str]]"
+      },
+      "FollowUpResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "contact_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Contact Id"
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "User Id"
+          },
+          "trigger_type": {
+            "type": "string",
+            "title": "Trigger Type"
+          },
+          "trigger_event_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger Event Id"
+          },
+          "suggested_message": {
+            "type": "string",
+            "title": "Suggested Message"
+          },
+          "suggested_channel": {
+            "type": "string",
+            "title": "Suggested Channel"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "pool": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pool"
+          },
+          "scheduled_for": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled For"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "contact_id",
+          "user_id",
+          "trigger_type",
+          "suggested_message",
+          "suggested_channel",
+          "status",
+          "created_at"
+        ],
+        "title": "FollowUpResponse"
+      },
+      "FrontendErrorReport": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "maxLength": 1000,
+            "title": "Message"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "lineno": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lineno"
+          },
+          "colno": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Colno"
+          },
+          "stack": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 5000
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stack"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 500
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "component": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 200
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Component"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "title": "FrontendErrorReport"
+      },
+      "GoogleAccountData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email"
+        ],
+        "title": "GoogleAccountData"
+      },
+      "GoogleCallbackRequest": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          }
+        },
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "title": "GoogleCallbackRequest"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "IdentityMatchData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "contact_a_id": {
+            "type": "string",
+            "title": "Contact A Id"
+          },
+          "contact_b_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contact B Id"
+          },
+          "contact_a": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContactSummaryData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contact_b": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContactSummaryData"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "match_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Match Score"
+          },
+          "match_method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Match Method"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "resolved_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "contact_a_id",
+          "status",
+          "created_at"
+        ],
+        "title": "IdentityMatchData"
+      },
+      "InteractionCreate": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform",
+            "default": "manual"
+          },
+          "direction": {
+            "type": "string",
+            "title": "Direction",
+            "default": "outbound"
+          },
+          "content_preview": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Preview"
+          },
+          "raw_reference_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Raw Reference Id"
+          },
+          "occurred_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Occurred At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "occurred_at"
+        ],
+        "title": "InteractionCreate"
+      },
+      "InteractionResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "contact_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Contact Id"
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "User Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "direction": {
+            "type": "string",
+            "title": "Direction"
+          },
+          "content_preview": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Preview"
+          },
+          "raw_reference_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Raw Reference Id"
+          },
+          "occurred_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Occurred At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "is_read_by_recipient": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Read By Recipient"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "contact_id",
+          "user_id",
+          "platform",
+          "direction",
+          "occurred_at",
+          "created_at"
+        ],
+        "title": "InteractionResponse"
+      },
+      "InteractionUpdate": {
+        "properties": {
+          "content_preview": {
+            "type": "string",
+            "title": "Content Preview"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content_preview"
+        ],
+        "title": "InteractionUpdate"
+      },
+      "LinkedInImportResult": {
+        "properties": {
+          "created": {
+            "type": "integer",
+            "title": "Created"
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Errors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "created",
+          "skipped",
+          "errors"
+        ],
+        "title": "LinkedInImportResult"
+      },
+      "LinkedInMessagePush": {
+        "properties": {
+          "profile_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile Id"
+          },
+          "profile_name": {
+            "type": "string",
+            "title": "Profile Name"
+          },
+          "direction": {
+            "type": "string",
+            "title": "Direction"
+          },
+          "content_preview": {
+            "type": "string",
+            "title": "Content Preview"
+          },
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "content_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Hash"
+          }
+        },
+        "type": "object",
+        "required": [
+          "profile_name",
+          "direction",
+          "content_preview",
+          "timestamp",
+          "conversation_id"
+        ],
+        "title": "LinkedInMessagePush"
+      },
+      "LinkedInMessagesImportResult": {
+        "properties": {
+          "new_interactions": {
+            "type": "integer",
+            "title": "New Interactions"
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped"
+          },
+          "unmatched": {
+            "type": "integer",
+            "title": "Unmatched"
+          },
+          "unmatched_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Unmatched Names"
+          }
+        },
+        "type": "object",
+        "required": [
+          "new_interactions",
+          "skipped",
+          "unmatched",
+          "unmatched_names"
+        ],
+        "title": "LinkedInMessagesImportResult"
+      },
+      "LinkedInProfilePush": {
+        "properties": {
+          "profile_id": {
+            "type": "string",
+            "title": "Profile Id"
+          },
+          "profile_url": {
+            "type": "string",
+            "title": "Profile Url"
+          },
+          "full_name": {
+            "type": "string",
+            "title": "Full Name"
+          },
+          "headline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Headline"
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "About"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "avatar_data": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "profile_id",
+          "profile_url",
+          "full_name"
+        ],
+        "title": "LinkedInProfilePush"
+      },
+      "LinkedInPushRequest": {
+        "properties": {
+          "profiles": {
+            "items": {
+              "$ref": "#/components/schemas/LinkedInProfilePush"
+            },
+            "type": "array",
+            "maxItems": 50,
+            "title": "Profiles",
+            "default": []
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/LinkedInMessagePush"
+            },
+            "type": "array",
+            "maxItems": 500,
+            "title": "Messages",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "LinkedInPushRequest"
+      },
+      "LinkedInPushResult": {
+        "properties": {
+          "contacts_created": {
+            "type": "integer",
+            "title": "Contacts Created"
+          },
+          "contacts_updated": {
+            "type": "integer",
+            "title": "Contacts Updated"
+          },
+          "interactions_created": {
+            "type": "integer",
+            "title": "Interactions Created"
+          },
+          "interactions_skipped": {
+            "type": "integer",
+            "title": "Interactions Skipped"
+          },
+          "backfill_needed": {
+            "items": {
+              "$ref": "#/components/schemas/BackfillItem"
+            },
+            "type": "array",
+            "title": "Backfill Needed",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "contacts_created",
+          "contacts_updated",
+          "interactions_created",
+          "interactions_skipped"
+        ],
+        "title": "LinkedInPushResult"
+      },
+      "MapConfig": {
+        "properties": {
+          "mapbox_public_token": {
+            "type": "string",
+            "title": "Mapbox Public Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mapbox_public_token"
+        ],
+        "title": "MapConfig"
+      },
+      "MarkedData": {
+        "properties": {
+          "marked": {
+            "type": "boolean",
+            "title": "Marked"
+          }
+        },
+        "type": "object",
+        "required": [
+          "marked"
+        ],
+        "title": "MarkedData"
+      },
+      "McpKeyData": {
+        "properties": {
+          "key": {
+            "type": "string",
+            "title": "Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key"
+        ],
+        "title": "McpKeyData"
+      },
+      "McpKeyRevokedData": {
+        "properties": {
+          "revoked": {
+            "type": "boolean",
+            "title": "Revoked"
+          }
+        },
+        "type": "object",
+        "required": [
+          "revoked"
+        ],
+        "title": "McpKeyRevokedData"
+      },
+      "McpKeyStatusData": {
+        "properties": {
+          "has_key": {
+            "type": "boolean",
+            "title": "Has Key"
+          }
+        },
+        "type": "object",
+        "required": [
+          "has_key"
+        ],
+        "title": "McpKeyStatusData"
+      },
+      "MergeOrganizationsRequest": {
+        "properties": {
+          "source_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Source Ids",
+            "description": "Organization IDs to merge away"
+          },
+          "target_id": {
+            "type": "string",
+            "title": "Target Id",
+            "description": "Organization ID to keep"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_ids",
+          "target_id"
+        ],
+        "title": "MergeOrganizationsRequest"
+      },
+      "MergeOrganizationsResult": {
+        "properties": {
+          "target_id": {
+            "type": "string",
+            "title": "Target Id"
+          },
+          "target_name": {
+            "type": "string",
+            "title": "Target Name"
+          },
+          "contacts_updated": {
+            "type": "integer",
+            "title": "Contacts Updated"
+          },
+          "source_organizations_merged": {
+            "type": "integer",
+            "title": "Source Organizations Merged"
+          }
+        },
+        "type": "object",
+        "required": [
+          "target_id",
+          "target_name",
+          "contacts_updated",
+          "source_organizations_merged"
+        ],
+        "title": "MergeOrganizationsResult"
+      },
+      "MergedContactData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "merged_contact_id": {
+            "type": "string",
+            "title": "Merged Contact Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "merged_contact_id"
+        ],
+        "title": "MergedContactData"
+      },
+      "MetaBackfillItem": {
+        "properties": {
+          "contact_id": {
+            "type": "string",
+            "title": "Contact Id"
+          },
+          "platform_id": {
+            "type": "string",
+            "title": "Platform Id"
+          },
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          }
+        },
+        "type": "object",
+        "required": [
+          "contact_id",
+          "platform_id",
+          "platform"
+        ],
+        "title": "MetaBackfillItem"
+      },
+      "MetaMessagePush": {
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "title": "Message Id"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "platform_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Platform Id"
+          },
+          "sender_name": {
+            "type": "string",
+            "title": "Sender Name"
+          },
+          "direction": {
+            "type": "string",
+            "title": "Direction"
+          },
+          "content_preview": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Preview"
+          },
+          "timestamp": {
+            "type": "string",
+            "title": "Timestamp"
+          },
+          "reactions": {
+            "items": {
+              "$ref": "#/components/schemas/MetaReaction"
+            },
+            "type": "array",
+            "title": "Reactions",
+            "default": []
+          },
+          "read_by": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Read By",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "message_id",
+          "conversation_id",
+          "sender_name",
+          "direction",
+          "timestamp"
+        ],
+        "title": "MetaMessagePush"
+      },
+      "MetaProfilePush": {
+        "properties": {
+          "platform_id": {
+            "type": "string",
+            "title": "Platform Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform_id",
+          "name"
+        ],
+        "title": "MetaProfilePush"
+      },
+      "MetaPushRequest": {
+        "properties": {
+          "platform": {
+            "type": "string",
+            "title": "Platform"
+          },
+          "profiles": {
+            "items": {
+              "$ref": "#/components/schemas/MetaProfilePush"
+            },
+            "type": "array",
+            "maxItems": 50,
+            "title": "Profiles",
+            "default": []
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/MetaMessagePush"
+            },
+            "type": "array",
+            "maxItems": 500,
+            "title": "Messages",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "platform"
+        ],
+        "title": "MetaPushRequest"
+      },
+      "MetaPushResult": {
+        "properties": {
+          "contacts_created": {
+            "type": "integer",
+            "title": "Contacts Created"
+          },
+          "contacts_updated": {
+            "type": "integer",
+            "title": "Contacts Updated"
+          },
+          "interactions_created": {
+            "type": "integer",
+            "title": "Interactions Created"
+          },
+          "interactions_skipped": {
+            "type": "integer",
+            "title": "Interactions Skipped"
+          },
+          "backfill_needed": {
+            "items": {
+              "$ref": "#/components/schemas/MetaBackfillItem"
+            },
+            "type": "array",
+            "title": "Backfill Needed",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "contacts_created",
+          "contacts_updated",
+          "interactions_created",
+          "interactions_skipped"
+        ],
+        "title": "MetaPushResult"
+      },
+      "MetaReaction": {
+        "properties": {
+          "reactor_id": {
+            "type": "string",
+            "title": "Reactor Id"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "reactor_id",
+          "type"
+        ],
+        "title": "MetaReaction"
+      },
+      "NotificationData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "notification_type": {
+            "type": "string",
+            "title": "Notification Type"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body"
+          },
+          "read": {
+            "type": "boolean",
+            "title": "Read"
+          },
+          "link": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "notification_type",
+          "title",
+          "read"
+        ],
+        "title": "NotificationData"
+      },
+      "NotificationListResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/NotificationData"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "NotificationListResponse"
+      },
+      "NotificationReadData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "read": {
+            "type": "boolean",
+            "title": "Read"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "read"
+        ],
+        "title": "NotificationReadData"
+      },
+      "OAuthUrlData": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url",
+          "state"
+        ],
+        "title": "OAuthUrlData"
+      },
+      "OrgContact": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "given_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Given Name"
+          },
+          "family_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Family Name"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "relationship_score": {
+            "type": "integer",
+            "title": "Relationship Score",
+            "default": 0
+          },
+          "last_interaction_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Interaction At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "OrgContact"
+      },
+      "OrgStatsResponse": {
+        "properties": {
+          "organization_id": {
+            "type": "string",
+            "title": "Organization Id"
+          },
+          "contact_count": {
+            "type": "integer",
+            "title": "Contact Count",
+            "default": 0
+          },
+          "avg_relationship_score": {
+            "type": "integer",
+            "title": "Avg Relationship Score",
+            "default": 0
+          },
+          "total_interactions": {
+            "type": "integer",
+            "title": "Total Interactions",
+            "default": 0
+          },
+          "last_interaction_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Interaction At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "organization_id"
+        ],
+        "title": "OrgStatsResponse"
+      },
+      "OrganizationCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Name"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Domain"
+          },
+          "industry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Industry"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "website": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Website"
+          },
+          "linkedin_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Url"
+          },
+          "twitter_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Handle"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "OrganizationCreate"
+      },
+      "OrganizationResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Domain"
+          },
+          "industry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Industry"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "website": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Website"
+          },
+          "linkedin_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Url"
+          },
+          "twitter_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Handle"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "logo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logo Url"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "contact_count": {
+            "type": "integer",
+            "title": "Contact Count",
+            "default": 0
+          },
+          "avg_relationship_score": {
+            "type": "integer",
+            "title": "Avg Relationship Score",
+            "default": 0
+          },
+          "total_interactions": {
+            "type": "integer",
+            "title": "Total Interactions",
+            "default": 0
+          },
+          "last_interaction_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Interaction At"
+          },
+          "contacts": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/OrgContact"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contacts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "OrganizationResponse"
+      },
+      "OrganizationUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Domain"
+          },
+          "industry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Industry"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
+          },
+          "website": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Website"
+          },
+          "linkedin_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Url"
+          },
+          "twitter_handle": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Handle"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "title": "OrganizationUpdate"
+      },
+      "PaginationMeta": {
+        "properties": {
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size"
+          },
+          "total_pages": {
+            "type": "integer",
+            "title": "Total Pages"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "page",
+          "page_size",
+          "total_pages"
+        ],
+        "title": "PaginationMeta"
+      },
+      "PairRequest": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "title": "PairRequest"
+      },
+      "PairTokenResponse": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "api_url": {
+            "type": "string",
+            "title": "Api Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "api_url"
+        ],
+        "title": "PairTokenResponse"
+      },
+      "PasswordChange": {
+        "properties": {
+          "current_password": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "Current Password"
+          },
+          "new_password": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "New Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "current_password",
+          "new_password"
+        ],
+        "title": "PasswordChange"
+      },
+      "PrioritySettingsData": {
+        "properties": {
+          "high": {
+            "type": "integer",
+            "title": "High"
+          },
+          "medium": {
+            "type": "integer",
+            "title": "Medium"
+          },
+          "low": {
+            "type": "integer",
+            "title": "Low"
+          }
+        },
+        "type": "object",
+        "required": [
+          "high",
+          "medium",
+          "low"
+        ],
+        "title": "PrioritySettingsData"
+      },
+      "PrioritySettingsInput": {
+        "properties": {
+          "high": {
+            "type": "integer",
+            "title": "High"
+          },
+          "medium": {
+            "type": "integer",
+            "title": "Medium"
+          },
+          "low": {
+            "type": "integer",
+            "title": "Low"
+          }
+        },
+        "type": "object",
+        "required": [
+          "high",
+          "medium",
+          "low"
+        ],
+        "title": "PrioritySettingsInput"
+      },
+      "ProfileUpdate": {
+        "properties": {
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 200
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          }
+        },
+        "type": "object",
+        "title": "ProfileUpdate"
+      },
+      "RegenerateBody": {
+        "properties": {
+          "channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channel"
+          }
+        },
+        "type": "object",
+        "title": "RegenerateBody"
+      },
+      "RegenerateResult": {
+        "properties": {
+          "suggested_message": {
+            "type": "string",
+            "title": "Suggested Message"
+          },
+          "suggested_channel": {
+            "type": "string",
+            "title": "Suggested Channel"
+          }
+        },
+        "type": "object",
+        "required": [
+          "suggested_message",
+          "suggested_channel"
+        ],
+        "title": "RegenerateResult"
+      },
+      "ScanResultData": {
+        "properties": {
+          "auto_merged": {
+            "type": "integer",
+            "title": "Auto Merged"
+          },
+          "pending_review": {
+            "type": "integer",
+            "title": "Pending Review"
+          },
+          "matches_found": {
+            "type": "integer",
+            "title": "Matches Found"
+          }
+        },
+        "type": "object",
+        "required": [
+          "auto_merged",
+          "pending_review",
+          "matches_found"
+        ],
+        "title": "ScanResultData"
+      },
+      "ScoresRecalculatedData": {
+        "properties": {
+          "updated": {
+            "type": "integer",
+            "title": "Updated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "updated"
+        ],
+        "title": "ScoresRecalculatedData"
+      },
+      "SendMessageBody": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "channel": {
+            "type": "string",
+            "title": "Channel"
+          },
+          "scheduled_for": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled For"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message",
+          "channel"
+        ],
+        "title": "SendMessageBody"
+      },
+      "SendMessageData": {
+        "properties": {
+          "sent": {
+            "type": "boolean",
+            "title": "Sent"
+          },
+          "channel": {
+            "type": "string",
+            "title": "Channel"
+          },
+          "interaction_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Interaction Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sent",
+          "channel"
+        ],
+        "title": "SendMessageData"
+      },
+      "SuggestionPrefsData": {
+        "properties": {
+          "max_suggestions": {
+            "type": "integer",
+            "title": "Max Suggestions"
+          },
+          "include_dormant": {
+            "type": "boolean",
+            "title": "Include Dormant"
+          },
+          "birthday_reminders": {
+            "type": "boolean",
+            "title": "Birthday Reminders"
+          },
+          "preferred_channel": {
+            "type": "string",
+            "title": "Preferred Channel"
+          }
+        },
+        "type": "object",
+        "required": [
+          "max_suggestions",
+          "include_dormant",
+          "birthday_reminders",
+          "preferred_channel"
+        ],
+        "title": "SuggestionPrefsData"
+      },
+      "SuggestionPrefsInput": {
+        "properties": {
+          "max_suggestions": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 20.0,
+                "minimum": 5.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Suggestions"
+          },
+          "include_dormant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Dormant"
+          },
+          "birthday_reminders": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Birthday Reminders"
+          },
+          "preferred_channel": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(auto|email|telegram|twitter)$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferred Channel"
+          }
+        },
+        "type": "object",
+        "title": "SuggestionPrefsInput"
+      },
+      "SuggestionUpdateBody": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "scheduled_for": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scheduled For"
+          },
+          "snooze_until": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snooze Until"
+          },
+          "suggested_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggested Message"
+          },
+          "suggested_channel": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggested Channel"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "SuggestionUpdateBody"
+      },
+      "SyncSettingsData": {
+        "properties": {
+          "telegram": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Telegram"
+          },
+          "gmail": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Gmail"
+          },
+          "twitter": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Twitter"
+          },
+          "linkedin": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Linkedin"
+          }
+        },
+        "type": "object",
+        "required": [
+          "telegram",
+          "gmail",
+          "twitter",
+          "linkedin"
+        ],
+        "title": "SyncSettingsData"
+      },
+      "SyncSettingsInput": {
+        "properties": {
+          "telegram": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram"
+          },
+          "gmail": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gmail"
+          },
+          "twitter": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter"
+          },
+          "linkedin": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin"
+          }
+        },
+        "type": "object",
+        "title": "SyncSettingsInput",
+        "description": "Per-platform sync configuration."
+      },
+      "SyncStartedData": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "SyncStartedData"
+      },
+      "TaxonomyResult": {
+        "properties": {
+          "categories": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Categories"
+          },
+          "total_tags": {
+            "type": "integer",
+            "title": "Total Tags"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "categories",
+          "total_tags",
+          "status"
+        ],
+        "title": "TaxonomyResult"
+      },
+      "TaxonomyUpdateBody": {
+        "properties": {
+          "categories": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "title": "Categories"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "categories"
+        ],
+        "title": "TaxonomyUpdateBody"
+      },
+      "Telegram2FARequest": {
+        "properties": {
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "password"
+        ],
+        "title": "Telegram2FARequest"
+      },
+      "TelegramConnectData": {
+        "properties": {
+          "phone_code_hash": {
+            "type": "string",
+            "title": "Phone Code Hash"
+          }
+        },
+        "type": "object",
+        "required": [
+          "phone_code_hash"
+        ],
+        "title": "TelegramConnectData"
+      },
+      "TelegramConnectRequest": {
+        "properties": {
+          "phone": {
+            "type": "string",
+            "title": "Phone"
+          }
+        },
+        "type": "object",
+        "required": [
+          "phone"
+        ],
+        "title": "TelegramConnectRequest"
+      },
+      "TelegramConnectedData": {
+        "properties": {
+          "connected": {
+            "type": "boolean",
+            "title": "Connected"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connected"
+        ],
+        "title": "TelegramConnectedData"
+      },
+      "TelegramSettingsData": {
+        "properties": {
+          "sync_2nd_tier": {
+            "type": "boolean",
+            "title": "Sync 2Nd Tier"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sync_2nd_tier"
+        ],
+        "title": "TelegramSettingsData"
+      },
+      "TelegramSettingsInput": {
+        "properties": {
+          "sync_2nd_tier": {
+            "type": "boolean",
+            "title": "Sync 2Nd Tier"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sync_2nd_tier"
+        ],
+        "title": "TelegramSettingsInput"
+      },
+      "TelegramVerifyData": {
+        "properties": {
+          "connected": {
+            "type": "boolean",
+            "title": "Connected"
+          },
+          "requires_2fa": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requires 2Fa"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connected"
+        ],
+        "title": "TelegramVerifyData"
+      },
+      "TelegramVerifyRequest": {
+        "properties": {
+          "phone": {
+            "type": "string",
+            "title": "Phone"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "phone_code_hash": {
+            "type": "string",
+            "title": "Phone Code Hash"
+          }
+        },
+        "type": "object",
+        "required": [
+          "phone",
+          "code",
+          "phone_code_hash"
+        ],
+        "title": "TelegramVerifyRequest"
+      },
+      "TokenData": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "token_type": {
+            "type": "string",
+            "title": "Token Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "token_type"
+        ],
+        "title": "TokenData"
+      },
+      "TwitterAuthUrlData": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "title": "Url"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          }
+        },
+        "type": "object",
+        "required": [
+          "url",
+          "state"
+        ],
+        "title": "TwitterAuthUrlData"
+      },
+      "TwitterBirdStatusData": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "checked_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checked At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "TwitterBirdStatusData"
+      },
+      "TwitterCallbackRequest": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          }
+        },
+        "type": "object",
+        "required": [
+          "code",
+          "state"
+        ],
+        "title": "TwitterCallbackRequest"
+      },
+      "TwitterConnectedData": {
+        "properties": {
+          "connected": {
+            "type": "boolean",
+            "title": "Connected"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username"
+          }
+        },
+        "type": "object",
+        "required": [
+          "connected"
+        ],
+        "title": "TwitterConnectedData"
+      },
+      "UnreadCountData": {
+        "properties": {
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "count"
+        ],
+        "title": "UnreadCountData"
+      },
+      "UserCreate": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "UserCreate"
+      },
+      "UserResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "google_connected": {
+            "type": "boolean",
+            "title": "Google Connected",
+            "default": false
+          },
+          "google_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Google Email"
+          },
+          "telegram_connected": {
+            "type": "boolean",
+            "title": "Telegram Connected",
+            "default": false
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "twitter_connected": {
+            "type": "boolean",
+            "title": "Twitter Connected",
+            "default": false
+          },
+          "twitter_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Username"
+          },
+          "linkedin_extension_paired_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Extension Paired At"
+          },
+          "whatsapp_connected": {
+            "type": "boolean",
+            "title": "Whatsapp Connected",
+            "default": false
+          },
+          "whatsapp_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Phone"
+          },
+          "meta_connected": {
+            "type": "boolean",
+            "title": "Meta Connected",
+            "default": false
+          },
+          "meta_connected_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta Connected Name"
+          },
+          "meta_sync_facebook": {
+            "type": "boolean",
+            "title": "Meta Sync Facebook",
+            "default": true
+          },
+          "meta_sync_instagram": {
+            "type": "boolean",
+            "title": "Meta Sync Instagram",
+            "default": true
+          },
+          "priority_settings": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority Settings"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "created_at"
+        ],
+        "title": "UserResponse"
+      },
+      "UserWithAccountsData": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "google_connected": {
+            "type": "boolean",
+            "title": "Google Connected",
+            "default": false
+          },
+          "google_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Google Email"
+          },
+          "telegram_connected": {
+            "type": "boolean",
+            "title": "Telegram Connected",
+            "default": false
+          },
+          "telegram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Telegram Username"
+          },
+          "twitter_connected": {
+            "type": "boolean",
+            "title": "Twitter Connected",
+            "default": false
+          },
+          "twitter_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Twitter Username"
+          },
+          "whatsapp_connected": {
+            "type": "boolean",
+            "title": "Whatsapp Connected",
+            "default": false
+          },
+          "whatsapp_phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Whatsapp Phone"
+          },
+          "linkedin_extension_paired_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Linkedin Extension Paired At"
+          },
+          "meta_connected": {
+            "type": "boolean",
+            "title": "Meta Connected",
+            "default": false
+          },
+          "meta_connected_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta Connected Name"
+          },
+          "meta_sync_facebook": {
+            "type": "boolean",
+            "title": "Meta Sync Facebook",
+            "default": true
+          },
+          "meta_sync_instagram": {
+            "type": "boolean",
+            "title": "Meta Sync Instagram",
+            "default": true
+          },
+          "google_accounts": {
+            "items": {
+              "$ref": "#/components/schemas/GoogleAccountData"
+            },
+            "type": "array",
+            "title": "Google Accounts",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "created_at"
+        ],
+        "title": "UserWithAccountsData"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WhatsAppSessionData": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "qr": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Qr"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "WhatsAppSessionData"
+      },
+      "WhatsAppStatusData": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "WhatsAppStatusData"
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordBearer": {
+        "type": "oauth2",
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "/api/v1/auth/login"
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -3,3 +3,4 @@ pytest>=8.0.0
 pytest-asyncio>=0.24.0
 pytest-xdist>=3.5.0
 lupa>=2.0  # Lua scripting backend for fakeredis — required by test_telegram_lock EVAL tests
+respx>=0.20

--- a/backend/tests/test_contact_geocode_listener.py
+++ b/backend/tests/test_contact_geocode_listener.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.models.contact import Contact
+
+
+@pytest.mark.asyncio
+async def test_listener_enqueues_on_new_contact_with_location(db_session, user_factory):
+    user = await user_factory()
+    with patch("app.models.listeners.geocode_contact") as mock_task:
+        contact = Contact(
+            id=uuid.uuid4(), user_id=user.id, full_name="Alice", location="Paris"
+        )
+        db_session.add(contact)
+        await db_session.commit()
+        mock_task.delay.assert_called_once_with(str(contact.id))
+
+
+@pytest.mark.asyncio
+async def test_listener_skips_when_location_unchanged(db_session, user_factory):
+    user = await user_factory()
+    contact = Contact(
+        id=uuid.uuid4(), user_id=user.id, full_name="Bob", location="Paris"
+    )
+    db_session.add(contact)
+    await db_session.commit()
+    with patch("app.models.listeners.geocode_contact") as mock_task:
+        contact.full_name = "Bob B."
+        await db_session.commit()
+        mock_task.delay.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_listener_enqueues_when_location_changes(db_session, user_factory):
+    user = await user_factory()
+    contact = Contact(
+        id=uuid.uuid4(), user_id=user.id, full_name="Carol", location="Paris"
+    )
+    db_session.add(contact)
+    await db_session.commit()
+    with patch("app.models.listeners.geocode_contact") as mock_task:
+        contact.location = "London"
+        await db_session.commit()
+        mock_task.delay.assert_called_once_with(str(contact.id))

--- a/backend/tests/test_contacts_map_api.py
+++ b/backend/tests/test_contacts_map_api.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.contact import Contact
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_map_endpoint_returns_contacts_in_bbox(
+    client: AsyncClient, test_user: User, auth_headers: dict, db
+):
+    db.add(Contact(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        full_name="Alice",
+        location="SF",
+        latitude=37.77,
+        longitude=-122.42,
+        relationship_score=80,
+    ))
+    db.add(Contact(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        full_name="Bob",
+        location="NYC",
+        latitude=40.71,
+        longitude=-74.00,
+        relationship_score=50,
+    ))
+    db.add(Contact(
+        id=uuid.uuid4(),
+        user_id=test_user.id,
+        full_name="Carol",
+        location="Mars",
+    ))
+    await db.commit()
+
+    resp = await client.get(
+        "/api/v1/contacts/map?bbox=-123,37,-122,38", headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    names = [p["full_name"] for p in body["data"]]
+    assert names == ["Alice"]
+    assert body["data"][0]["latitude"] == pytest.approx(37.77)
+    assert body["meta"]["total_in_bounds"] == 1
+
+
+@pytest.mark.asyncio
+async def test_map_endpoint_isolates_users(
+    client: AsyncClient, test_user: User, auth_headers: dict, user_factory, db
+):
+    other = await user_factory()
+    db.add(Contact(
+        id=uuid.uuid4(),
+        user_id=other.id,
+        full_name="Eve",
+        location="SF",
+        latitude=37.77,
+        longitude=-122.42,
+    ))
+    await db.commit()
+
+    resp = await client.get(
+        "/api/v1/contacts/map?bbox=-123,37,-122,38", headers=auth_headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_map_endpoint_caps_at_500(
+    client: AsyncClient, test_user: User, auth_headers: dict, db
+):
+    for _ in range(510):
+        db.add(Contact(
+            id=uuid.uuid4(),
+            user_id=test_user.id,
+            full_name="C",
+            location="SF",
+            latitude=37.77,
+            longitude=-122.42,
+        ))
+    await db.commit()
+
+    resp = await client.get(
+        "/api/v1/contacts/map?bbox=-123,37,-122,38&limit=1000", headers=auth_headers
+    )
+    body = resp.json()
+    assert len(body["data"]) == 500
+    assert body["meta"]["total_in_bounds"] == 510
+
+
+@pytest.mark.asyncio
+async def test_map_endpoint_rejects_bad_bbox(
+    client: AsyncClient, auth_headers: dict
+):
+    resp = await client.get(
+        "/api/v1/contacts/map?bbox=not-a-bbox", headers=auth_headers
+    )
+    assert resp.status_code == 400

--- a/backend/tests/test_geocode_backfill.py
+++ b/backend/tests/test_geocode_backfill.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.contact import Contact
+from app.services.task_jobs.geocoding import _do_backfill
+
+
+@pytest.mark.asyncio
+async def test_backfill_enqueues_only_ungeocoded(db_session, user_factory):
+    user = await user_factory()
+    c1 = Contact(
+        id=uuid.uuid4(), user_id=user.id, full_name="A", location="Paris"
+    )  # needs geocode
+    c2 = Contact(
+        id=uuid.uuid4(), user_id=user.id, full_name="B", location="Berlin",
+        geocoded_location="Berlin", latitude=52.5, longitude=13.4,
+    )  # already done
+    c3 = Contact(
+        id=uuid.uuid4(), user_id=user.id, full_name="C", location=None
+    )  # no location
+    db_session.add_all([c1, c2, c3])
+    await db_session.commit()
+
+    mock_task = MagicMock()
+    mock_task.delay = MagicMock()
+
+    with patch(
+        "app.services.task_jobs.geocoding.geocode_contact", mock_task
+    ):
+        await _do_backfill(db_session)
+
+    calls = [c.args[0] for c in mock_task.delay.call_args_list]
+    assert str(c1.id) in calls
+    assert str(c2.id) not in calls
+    assert str(c3.id) not in calls

--- a/backend/tests/test_geocode_task.py
+++ b/backend/tests/test_geocode_task.py
@@ -34,3 +34,80 @@ async def test_do_geocode_stores_coordinates(db_session, user_factory):
     assert contact.longitude == pytest.approx(-122.42)
     assert contact.geocoded_location == "San Francisco, CA"
     assert contact.geocoded_at is not None
+
+
+@pytest.mark.asyncio
+async def test_do_geocode_skips_when_unchanged(db_session, user_factory):
+    from unittest.mock import AsyncMock, MagicMock
+    user = await user_factory()
+    contact = Contact(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        full_name="Bob",
+        location="Berlin",
+        geocoded_location="Berlin",
+        latitude=52.52,
+        longitude=13.40,
+        geocoded_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    db_session.add(contact)
+    await db_session.commit()
+
+    geocoder = MagicMock()
+    geocoder.geocode = AsyncMock()
+    await _do_geocode(db_session, str(contact.id), geocoder)
+    geocoder.geocode.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_do_geocode_clears_when_location_blanked(db_session, user_factory):
+    from unittest.mock import AsyncMock, MagicMock
+    user = await user_factory()
+    contact = Contact(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        full_name="Carol",
+        location=None,
+        geocoded_location="Berlin",
+        latitude=52.52,
+        longitude=13.40,
+    )
+    db_session.add(contact)
+    await db_session.commit()
+
+    geocoder = MagicMock()
+    geocoder.geocode = AsyncMock()
+    await _do_geocode(db_session, str(contact.id), geocoder)
+    await db_session.refresh(contact)
+
+    assert contact.latitude is None
+    assert contact.longitude is None
+    assert contact.geocoded_location is None
+    assert contact.geocoded_at is not None
+    geocoder.geocode.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_do_geocode_sets_sentinel_on_not_found(db_session, user_factory):
+    from unittest.mock import AsyncMock
+    from app.services.geocoding import GeocodingNotFoundError
+
+    user = await user_factory()
+    contact = Contact(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        full_name="Dan",
+        location="asdfghjkl",
+    )
+    db_session.add(contact)
+    await db_session.commit()
+
+    geocoder = AsyncMock()
+    geocoder.geocode = AsyncMock(side_effect=GeocodingNotFoundError("no"))
+    await _do_geocode(db_session, str(contact.id), geocoder)
+    await db_session.refresh(contact)
+
+    assert contact.latitude is None
+    assert contact.longitude is None
+    assert contact.geocoded_location == "asdfghjkl"
+    assert contact.geocoded_at is not None

--- a/backend/tests/test_geocode_task.py
+++ b/backend/tests/test_geocode_task.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models.contact import Contact
+from app.services.task_jobs.geocoding import _do_geocode
+
+
+@pytest.mark.asyncio
+async def test_do_geocode_stores_coordinates(db_session, user_factory):
+    user = await user_factory()
+    contact = Contact(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        full_name="Alice",
+        location="San Francisco, CA",
+    )
+    db_session.add(contact)
+    await db_session.commit()
+
+    geocoder = AsyncMock()
+    geocoder.geocode = AsyncMock(
+        return_value=type("R", (), {"latitude": 37.77, "longitude": -122.42})()
+    )
+
+    await _do_geocode(db_session, str(contact.id), geocoder)
+    await db_session.refresh(contact)
+
+    assert contact.latitude == pytest.approx(37.77)
+    assert contact.longitude == pytest.approx(-122.42)
+    assert contact.geocoded_location == "San Francisco, CA"
+    assert contact.geocoded_at is not None

--- a/backend/tests/test_geocoding_mapbox.py
+++ b/backend/tests/test_geocoding_mapbox.py
@@ -30,3 +30,53 @@ async def test_geocode_returns_lat_lng_on_success():
         result = await geocoder.geocode("San Francisco, CA")
         assert result.latitude == 37.7749
         assert result.longitude == -122.4194
+
+
+@pytest.mark.asyncio
+async def test_geocode_raises_not_found_on_empty_features():
+    with respx.mock() as mock:
+        mock.get("https://api.mapbox.com/search/geocode/v6/forward").respond(200, json={"features": []})
+        geocoder = MapboxGeocoder(token="test-token")
+        with pytest.raises(GeocodingNotFoundError):
+            await geocoder.geocode("nowhere")
+
+
+@pytest.mark.asyncio
+async def test_geocode_raises_not_found_on_4xx():
+    with respx.mock() as mock:
+        mock.get("https://api.mapbox.com/search/geocode/v6/forward").respond(400, json={})
+        geocoder = MapboxGeocoder(token="test-token")
+        with pytest.raises(GeocodingNotFoundError):
+            await geocoder.geocode("bad query")
+
+
+@pytest.mark.asyncio
+async def test_geocode_raises_rate_limit_on_429():
+    with respx.mock() as mock:
+        mock.get("https://api.mapbox.com/search/geocode/v6/forward").respond(429, json={})
+        geocoder = MapboxGeocoder(token="test-token")
+        with pytest.raises(GeocodingRateLimitError):
+            await geocoder.geocode("anywhere")
+
+
+@pytest.mark.asyncio
+async def test_geocode_retries_on_5xx_then_succeeds():
+    with respx.mock() as mock:
+        route = mock.get("https://api.mapbox.com/search/geocode/v6/forward")
+        route.mock(
+            side_effect=[
+                httpx.Response(502, json={}),
+                httpx.Response(
+                    200,
+                    json={
+                        "features": [
+                            {"geometry": {"coordinates": [10.0, 20.0], "type": "Point"}, "properties": {}}
+                        ]
+                    },
+                ),
+            ]
+        )
+        geocoder = MapboxGeocoder(token="test-token")
+        result = await geocoder.geocode("Berlin")
+        assert result.latitude == 20.0
+        assert result.longitude == 10.0

--- a/backend/tests/test_geocoding_mapbox.py
+++ b/backend/tests/test_geocoding_mapbox.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from app.services.geocoding import (
+    GeocodingNotFoundError,
+    GeocodingRateLimitError,
+    GeocodingError,
+    MapboxGeocoder,
+)
+
+
+@pytest.mark.asyncio
+async def test_geocode_returns_lat_lng_on_success():
+    with respx.mock(assert_all_called=True) as mock:
+        mock.get("https://api.mapbox.com/search/geocode/v6/forward").respond(
+            200,
+            json={
+                "features": [
+                    {
+                        "geometry": {"type": "Point", "coordinates": [-122.4194, 37.7749]},
+                        "properties": {"name": "San Francisco"},
+                    }
+                ]
+            },
+        )
+        geocoder = MapboxGeocoder(token="test-token")
+        result = await geocoder.geocode("San Francisco, CA")
+        assert result.latitude == 37.7749
+        assert result.longitude == -122.4194

--- a/backend/tests/test_map_config_api.py
+++ b/backend/tests/test_map_config_api.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_map_config_returns_public_token(
+    client: AsyncClient, auth_headers: dict, monkeypatch
+):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "MAPBOX_PUBLIC_TOKEN", "pk.test")
+    resp = await client.get("/api/v1/map/config", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["mapbox_public_token"] == "pk.test"
+
+
+@pytest.mark.asyncio
+async def test_map_config_empty_when_unset(
+    client: AsyncClient, auth_headers: dict, monkeypatch
+):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "MAPBOX_PUBLIC_TOKEN", "")
+    resp = await client.get("/api/v1/map/config", headers=auth_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["data"]["mapbox_public_token"] == ""
+
+
+@pytest.mark.asyncio
+async def test_map_config_requires_auth(client: AsyncClient):
+    resp = await client.get("/api/v1/map/config")
+    # 401 or 403 depending on project auth dep behavior — anything non-200 is fine
+    assert resp.status_code in (401, 403)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,11 +13,13 @@
         "clsx": "^2.1.0",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.460.0",
+        "mapbox-gl": "^3.21.0",
         "next": "15.1.0",
         "openapi-fetch": "^0.17.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-map-gl": "^8.1.1",
         "tailwind-merge": "^2.6.0"
       },
       "devDependencies": {
@@ -1705,6 +1707,68 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
+      "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
+      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2866,6 +2930,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2890,6 +2969,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2908,6 +2993,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3461,6 +3555,41 @@
         "win32"
       ]
     },
+    "node_modules/@vis.gl/react-mapbox": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.1.1.tgz",
+      "integrity": "sha512-KMDTjtWESXxHS4uqWxjsvgQUHvuL3Z6SdKe68o7Nxma2qUfuyH3x4TCkIqGn3FQTrFvZLWvTnSAbGvtm+Kd13A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "mapbox-gl": ">=3.5.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vis.gl/react-maplibre": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-maplibre/-/react-maplibre-8.1.1.tgz",
+      "integrity": "sha512-iUOfzJAhFAJwEZp1644tQb7LOTFgi5/GzdaztkhzNgFVuoF2Ez7guvwZjQAKB9CN2TlHTgNuYH8UW85kO7cVhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^19.2.1"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=4.0.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
@@ -3728,6 +3857,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -3896,6 +4034,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ast-types-flow": {
@@ -4086,6 +4233,25 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "node_modules/bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4198,6 +4364,12 @@
       "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cheap-ruler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
+      "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
+      "license": "ISC"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -4326,6 +4498,12 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
       "license": "MIT"
     },
     "node_modules/cssstyle": {
@@ -4578,6 +4756,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
@@ -5316,6 +5500,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5568,6 +5764,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5636,6 +5838,21 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5696,6 +5913,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -6064,6 +6287,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6174,6 +6406,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -6341,6 +6585,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6514,6 +6767,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -6542,6 +6801,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -6952,6 +7217,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mapbox-gl": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.21.0.tgz",
+      "integrity": "sha512-0mv/LHDoW6QmxLEoNqCPuby428WTekfs38TtNXd/cxDOLdY6kFd/ztaSkcBeqNksbYSz2lXnPfBm8nN5+hxA0w==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "workspaces": [
+        "src/style-spec",
+        "packages/pmtiles-provider",
+        "test/build/vite",
+        "test/build/webpack",
+        "test/build/typings"
+      ],
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^3.0.0",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/geojson-vt": "^3.2.5",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "cheap-ruler": "^4.0.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^3.0.1",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.4",
+        "grid-index": "^1.1.0",
+        "kdbush": "^4.0.2",
+        "martinez-polygon-clipping": "^0.8.1",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0"
+      }
+    },
+    "node_modules/martinez-polygon-clipping": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz",
+      "integrity": "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^2.0.4",
+        "splaytree": "^0.1.4",
+        "tinyqueue": "3.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7040,7 +7355,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7051,6 +7365,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7542,6 +7862,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7610,6 +7942,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7670,6 +8008,12 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -7716,6 +8060,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -7743,6 +8093,30 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-map-gl": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.1.1.tgz",
+      "integrity": "sha512-aSqFAFoxvY7wxbGI93Dz0E41171mkAb3GcNbnkFIotmu88OFw495os6mIDZSi7irYNT/PZEIOEHUxhun4ToGuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vis.gl/react-mapbox": "8.1.1",
+        "@vis.gl/react-maplibre": "8.1.1"
+      },
+      "peerDependencies": {
+        "mapbox-gl": ">=1.13.0",
+        "maplibre-gl": ">=1.13.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -7863,6 +8237,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7873,6 +8256,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -7942,6 +8331,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -8077,6 +8472,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sharp": {
@@ -8235,11 +8645,89 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/splaytree": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
+      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+      "license": "MIT"
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8459,6 +8947,15 @@
         }
       }
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8587,6 +9084,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
@@ -8807,6 +9310,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "node_modules/typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -8842,6 +9360,21 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,11 +17,13 @@
     "clsx": "^2.1.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.460.0",
+    "mapbox-gl": "^3.21.0",
     "next": "15.1.0",
     "openapi-fetch": "^0.17.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-map-gl": "^8.1.1",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/frontend/src/app/contacts/[id]/_components/details-panel.tsx
+++ b/frontend/src/app/contacts/[id]/_components/details-panel.tsx
@@ -438,6 +438,11 @@ export function DetailsPanel({
           label="Location"
           value={contact.location}
           onSave={(v) => onSaveField("location", v)}
+          internalHref={
+            contact.latitude != null && contact.longitude != null
+              ? `/map?focus=${contact.id}`
+              : undefined
+          }
         />
         <InlineField
           label="Birthday"

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+import { ContactMap } from "@/components/map/contact-map";
+import { MapSidebar } from "@/components/map/map-sidebar";
+import { ContactPinPopover } from "@/components/map/contact-pin-popover";
+import { useMapConfig } from "@/hooks/use-map-config";
+import { useViewportContacts, type Bbox } from "@/hooks/use-viewport-contacts";
+import { client } from "@/lib/api-client";
+import type { components } from "@/lib/api-types";
+
+type Pin = components["schemas"]["ContactMapPin"];
+
+export default function MapPage() {
+  const { data: config, isLoading: configLoading } = useMapConfig();
+  const searchParams = useSearchParams();
+  const focusId = searchParams.get("focus");
+  const [focus, setFocus] = useState<{ latitude: number; longitude: number } | null>(null);
+  const [bbox, setBbox] = useState<Bbox | null>(null);
+  const [selected, setSelected] = useState<Pin | null>(null);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!focusId) return;
+    let cancelled = false;
+    (async () => {
+      const { data } = await client.GET("/api/v1/contacts/{contact_id}", {
+        params: { path: { contact_id: focusId } },
+      });
+      if (cancelled) return;
+      const c = data?.data;
+      if (c && c.latitude != null && c.longitude != null) {
+        setFocus({ latitude: c.latitude, longitude: c.longitude });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [focusId]);
+
+  const onViewport = useCallback((b: Bbox) => setBbox(b), []);
+  const { data: viewportData } = useViewportContacts(bbox);
+  const pins = (viewportData?.data ?? []) as Pin[];
+  const total = (viewportData?.meta as { total_in_bounds?: number } | null)?.total_in_bounds ?? 0;
+
+  if (configLoading) return <div className="p-8">Loading map…</div>;
+  if (!config?.mapbox_public_token) {
+    return (
+      <div className="p-8 text-stone-600 dark:text-stone-300">
+        Map is not yet configured. Ask an admin to set{" "}
+        <code>MAPBOX_PUBLIC_TOKEN</code>.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-4rem)]">
+      <div className="flex-1 relative">
+        <ContactMap
+          token={config.mapbox_public_token}
+          pins={pins}
+          focus={focus}
+          onViewportChange={onViewport}
+          onPinClick={setSelected}
+          hoveredId={hoveredId}
+        />
+        {selected && (
+          <div className="absolute top-4 left-4 z-10">
+            <ContactPinPopover pin={selected} onClose={() => setSelected(null)} />
+          </div>
+        )}
+      </div>
+      <MapSidebar
+        pins={pins}
+        totalInBounds={total}
+        onHover={setHoveredId}
+        selectedId={selected?.id ?? null}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/map/contact-map.tsx
+++ b/frontend/src/components/map/contact-map.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { MapRef } from "react-map-gl/mapbox";
+import type { MapMouseEvent } from "mapbox-gl";
+import Map, { Layer, Source } from "react-map-gl/mapbox";
+import "mapbox-gl/dist/mapbox-gl.css";
+
+import type { components } from "@/lib/api-types";
+import type { Bbox } from "@/hooks/use-viewport-contacts";
+
+type Pin = components["schemas"]["ContactMapPin"];
+
+export interface ContactMapProps {
+  token: string;
+  pins: Pin[];
+  focus?: { latitude: number; longitude: number } | null;
+  onViewportChange: (bbox: Bbox) => void;
+  onPinClick: (pin: Pin) => void;
+  hoveredId: string | null;
+}
+
+const SOURCE_ID = "contact-pins";
+
+export function ContactMap({
+  token,
+  pins,
+  focus,
+  onViewportChange,
+  onPinClick,
+  hoveredId,
+}: ContactMapProps) {
+  const mapRef = useRef<MapRef | null>(null);
+  const [initial] = useState(() =>
+    focus
+      ? { longitude: focus.longitude, latitude: focus.latitude, zoom: 10 }
+      : { longitude: 0, latitude: 20, zoom: 1.5 },
+  );
+
+  const geojson = useMemo(
+    () => ({
+      type: "FeatureCollection" as const,
+      features: pins.map((p) => ({
+        type: "Feature" as const,
+        geometry: {
+          type: "Point" as const,
+          coordinates: [p.longitude, p.latitude],
+        },
+        properties: {
+          id: p.id,
+          name: p.full_name,
+          score: p.relationship_score,
+        },
+      })),
+    }),
+    [pins],
+  );
+
+  const emitBounds = useCallback(() => {
+    const m = mapRef.current;
+    if (!m) return;
+    const b = m.getMap().getBounds();
+    if (!b) return;
+    onViewportChange({
+      minLng: b.getWest(),
+      minLat: b.getSouth(),
+      maxLng: b.getEast(),
+      maxLat: b.getNorth(),
+    });
+  }, [onViewportChange]);
+
+  const handleClick = useCallback(
+    (e: MapMouseEvent) => {
+      const feature = e.features?.[0];
+      if (!feature) return;
+      if (feature.layer?.id === "clusters") {
+        const clusterId = feature.properties?.cluster_id;
+        const src = mapRef.current?.getMap().getSource(SOURCE_ID) as
+          | { getClusterExpansionZoom: (id: number, cb: (err: unknown, zoom: number) => void) => void }
+          | undefined;
+        src?.getClusterExpansionZoom(clusterId, (err: unknown, zoom: number) => {
+          if (err) return;
+          const coords = (feature.geometry as unknown as { coordinates: [number, number] }).coordinates;
+          mapRef.current?.easeTo({ center: coords, zoom });
+        });
+        return;
+      }
+      if (feature.layer?.id === "unclustered-point") {
+        const id = feature.properties?.id as string;
+        const pin = pins.find((p) => p.id === id);
+        if (pin) onPinClick(pin);
+      }
+    },
+    [pins, onPinClick],
+  );
+
+  return (
+    <Map
+      ref={mapRef}
+      mapboxAccessToken={token}
+      initialViewState={initial}
+      mapStyle="mapbox://styles/mapbox/streets-v12"
+      onLoad={emitBounds}
+      onMoveEnd={emitBounds}
+      onClick={handleClick}
+      interactiveLayerIds={["clusters", "unclustered-point"]}
+      style={{ width: "100%", height: "100%" }}
+    >
+      <Source
+        id={SOURCE_ID}
+        type="geojson"
+        data={geojson}
+        cluster
+        clusterMaxZoom={14}
+        clusterRadius={50}
+      >
+        <Layer
+          id="clusters"
+          type="circle"
+          filter={["has", "point_count"]}
+          paint={{
+            "circle-color": "#0d9488",
+            "circle-radius": [
+              "step",
+              ["get", "point_count"],
+              16,
+              10,
+              22,
+              50,
+              30,
+            ],
+            "circle-opacity": 0.85,
+          }}
+        />
+        <Layer
+          id="cluster-count"
+          type="symbol"
+          filter={["has", "point_count"]}
+          layout={{
+            "text-field": ["get", "point_count_abbreviated"],
+            "text-size": 12,
+          }}
+          paint={{ "text-color": "#fff" }}
+        />
+        <Layer
+          id="unclustered-point"
+          type="circle"
+          filter={["!", ["has", "point_count"]]}
+          paint={{
+            "circle-color": [
+              "case",
+              ["==", ["get", "id"], hoveredId ?? ""],
+              "#dc2626",
+              "#0d9488",
+            ],
+            "circle-radius": 7,
+            "circle-stroke-width": 2,
+            "circle-stroke-color": "#fff",
+          }}
+        />
+      </Source>
+    </Map>
+  );
+}

--- a/frontend/src/components/map/contact-pin-popover.tsx
+++ b/frontend/src/components/map/contact-pin-popover.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import type { components } from "@/lib/api-types";
+
+type Pin = components["schemas"]["ContactMapPin"];
+
+export function ContactPinPopover({
+  pin,
+  onClose,
+}: {
+  pin: Pin;
+  onClose: () => void;
+}) {
+  return (
+    <div className="bg-white dark:bg-stone-900 border border-stone-200 dark:border-stone-700 rounded-lg shadow-lg p-3 min-w-[220px] text-sm">
+      <div className="flex items-center gap-2 mb-2">
+        {pin.avatar_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={pin.avatar_url} alt="" className="w-8 h-8 rounded-full" />
+        ) : (
+          <div className="w-8 h-8 rounded-full bg-stone-200 dark:bg-stone-700" />
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="font-medium truncate text-stone-900 dark:text-stone-100">
+            {pin.full_name ?? "Unnamed"}
+          </div>
+          <div className="text-xs text-stone-500 dark:text-stone-400">
+            Score {pin.relationship_score}
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="text-stone-400 hover:text-stone-700 dark:hover:text-stone-200"
+        >
+          ×
+        </button>
+      </div>
+      <Link
+        href={`/contacts/${pin.id}`}
+        className="text-xs font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700"
+      >
+        Open contact →
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/components/map/map-sidebar.tsx
+++ b/frontend/src/components/map/map-sidebar.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import type { components } from "@/lib/api-types";
+
+type Pin = components["schemas"]["ContactMapPin"];
+
+export function MapSidebar({
+  pins,
+  totalInBounds,
+  onHover,
+  selectedId,
+}: {
+  pins: Pin[];
+  totalInBounds: number;
+  onHover: (id: string | null) => void;
+  selectedId: string | null;
+}) {
+  return (
+    <aside className="w-80 border-l border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 overflow-y-auto">
+      <div className="p-3 text-xs text-stone-500 dark:text-stone-400 border-b border-stone-200 dark:border-stone-800">
+        {totalInBounds > pins.length
+          ? `Showing ${pins.length} of ${totalInBounds} — zoom in for more`
+          : `${pins.length} contact${pins.length === 1 ? "" : "s"} in view`}
+      </div>
+      <ul>
+        {pins.map((p) => (
+          <li
+            key={p.id}
+            onMouseEnter={() => onHover(p.id)}
+            onMouseLeave={() => onHover(null)}
+            className={`px-3 py-2 border-b border-stone-100 dark:border-stone-800 hover:bg-stone-50 dark:hover:bg-stone-800 ${
+              selectedId === p.id ? "bg-teal-50 dark:bg-teal-950/40" : ""
+            }`}
+          >
+            <Link href={`/contacts/${p.id}`} className="flex items-center gap-2">
+              {p.avatar_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={p.avatar_url} alt="" className="w-8 h-8 rounded-full" />
+              ) : (
+                <div className="w-8 h-8 rounded-full bg-stone-200 dark:bg-stone-700" />
+              )}
+              <div className="flex-1 min-w-0">
+                <div className="truncate font-medium text-stone-900 dark:text-stone-100">
+                  {p.full_name ?? "Unnamed"}
+                </div>
+                <div className="text-xs text-stone-500 dark:text-stone-400">
+                  Score {p.relationship_score}
+                </div>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/frontend/src/components/nav.tsx
+++ b/frontend/src/components/nav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "@/hooks/use-auth";
-import { LayoutDashboard, Users, Building2, Sparkles, GitMerge, Settings, Bell, LogOut, ChevronDown, Archive, Search, Menu, X } from "lucide-react";
+import { Archive, Bell, Building2, ChevronDown, GitMerge, LayoutDashboard, LogOut, MapPinned, Menu, Search, Settings, Sparkles, Users, X } from "lucide-react";
 import { useUnreadCount } from "@/hooks/use-notifications";
 import { useContacts } from "@/hooks/use-contacts";
 import { useTelegramSyncProgress } from "@/hooks/use-telegram-sync";
@@ -30,6 +30,7 @@ const navLinks = [
       { href: "/identity", label: "Resolve Duplicates", icon: GitMerge },
     ],
   },
+  { href: "/map", label: "Map", icon: MapPinned },
   { href: "/organizations", label: "Orgs", icon: Building2 },
   { href: "/settings", label: "Settings", icon: Settings },
 ];

--- a/frontend/src/hooks/use-contacts.ts
+++ b/frontend/src/hooks/use-contacts.ts
@@ -19,6 +19,8 @@ export interface Contact {
   telegram_bio: string | null;
   telegram_last_seen_at: string | null;
   location: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
   birthday: string | null;
   linkedin_url: string | null;
   whatsapp_phone: string | null;

--- a/frontend/src/hooks/use-map-config.ts
+++ b/frontend/src/hooks/use-map-config.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { client } from "@/lib/api-client";
+
+export function useMapConfig() {
+  return useQuery({
+    queryKey: ["map", "config"],
+    queryFn: async () => {
+      const { data } = await client.GET("/api/v1/map/config");
+      return data?.data ?? { mapbox_public_token: "" };
+    },
+    staleTime: 5 * 60_000,
+  });
+}

--- a/frontend/src/hooks/use-viewport-contacts.ts
+++ b/frontend/src/hooks/use-viewport-contacts.ts
@@ -1,0 +1,25 @@
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { client } from "@/lib/api-client";
+
+export interface Bbox {
+  minLng: number;
+  minLat: number;
+  maxLng: number;
+  maxLat: number;
+}
+
+export function useViewportContacts(bbox: Bbox | null) {
+  return useQuery({
+    queryKey: ["contacts", "map", bbox],
+    enabled: bbox !== null,
+    placeholderData: keepPreviousData,
+    queryFn: async () => {
+      if (!bbox) return { data: [], meta: { total_in_bounds: 0 } };
+      const param = `${bbox.minLng},${bbox.minLat},${bbox.maxLng},${bbox.maxLat}`;
+      const { data } = await client.GET("/api/v1/contacts/map", {
+        params: { query: { bbox: param, limit: 500 } },
+      });
+      return data ?? { data: [], meta: { total_in_bounds: 0 } };
+    },
+  });
+}

--- a/frontend/src/lib/api-types.d.ts
+++ b/frontend/src/lib/api-types.d.ts
@@ -501,6 +501,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/contacts/map": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Contacts Map */
+        get: operations["contacts_map_api_v1_contacts_map_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/contacts/bulk-update": {
         parameters: {
             query?: never;
@@ -1970,6 +1987,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/map/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Map Config */
+        get: operations["map_config_api_v1_map_config_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/errors": {
         parameters: {
             query?: never;
@@ -2205,6 +2239,24 @@ export interface components {
             error?: string | null;
             meta: components["schemas"]["PaginationMeta"];
         };
+        /** ContactMapPin */
+        ContactMapPin: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Full Name */
+            full_name: string | null;
+            /** Avatar Url */
+            avatar_url: string | null;
+            /** Latitude */
+            latitude: number;
+            /** Longitude */
+            longitude: number;
+            /** Relationship Score */
+            relationship_score: number;
+        };
         /** ContactResponse */
         ContactResponse: {
             /** Full Name */
@@ -2303,6 +2355,10 @@ export interface components {
             user_edited_fields: string[];
             /** Bcc Hash */
             bcc_hash?: string | null;
+            /** Latitude */
+            latitude?: number | null;
+            /** Longitude */
+            longitude?: number | null;
             /**
              * Created At
              * Format: date-time
@@ -2648,6 +2704,16 @@ export interface components {
         /** Envelope[LinkedInPushResult] */
         Envelope_LinkedInPushResult_: {
             data?: components["schemas"]["LinkedInPushResult"] | null;
+            /** Error */
+            error?: string | null;
+            /** Meta */
+            meta?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** Envelope[MapConfig] */
+        Envelope_MapConfig_: {
+            data?: components["schemas"]["MapConfig"] | null;
             /** Error */
             error?: string | null;
             /** Meta */
@@ -3019,6 +3085,17 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
+        /** Envelope[list[ContactMapPin]] */
+        Envelope_list_ContactMapPin__: {
+            /** Data */
+            data?: components["schemas"]["ContactMapPin"][] | null;
+            /** Error */
+            error?: string | null;
+            /** Meta */
+            meta?: {
+                [key: string]: unknown;
+            } | null;
+        };
         /** Envelope[list[DuplicateContactData]] */
         Envelope_list_DuplicateContactData__: {
             /** Data */
@@ -3358,6 +3435,11 @@ export interface components {
              * @default []
              */
             backfill_needed: components["schemas"]["BackfillItem"][];
+        };
+        /** MapConfig */
+        MapConfig: {
+            /** Mapbox Public Token */
+            mapbox_public_token: string;
         };
         /** MarkedData */
         MarkedData: {
@@ -4870,6 +4952,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Envelope"];
+                };
+            };
+        };
+    };
+    contacts_map_api_v1_contacts_map_get: {
+        parameters: {
+            query: {
+                /** @description minLng,minLat,maxLng,maxLat */
+                bbox: string;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Envelope_list_ContactMapPin__"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -7401,6 +7516,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Envelope_TwitterBirdStatusData_"];
+                };
+            };
+        };
+    };
+    map_config_api_v1_map_config_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Envelope_MapConfig_"];
                 };
             };
         };

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -141,6 +141,8 @@ vi.mock("lucide-react", () => {
     Loader2: makeIcon("Loader2"),
     Wand2: makeIcon("Wand2"),
     RotateCcw: makeIcon("RotateCcw"),
+    // map page
+    MapPinned: makeIcon("MapPinned"),
     // organizations page
     BarChart3: makeIcon("BarChart3"),
     MessageSquare: makeIcon("MessageSquare"),


### PR DESCRIPTION
## Summary

- New `/map` route renders contacts as clustered pins on Mapbox tiles, with a viewport-filtered sidebar list; the Location field on contact pages links to `/map?focus=<id>` when the contact has coordinates.
- Contacts are geocoded automatically via a Celery task that fires on `Contact.location` changes (and a `backfill_all_contacts` admin task for existing rows); Mapbox Geocoding v6 with retry/rate-limit/not-found handling.
- Two new endpoints: `GET /api/v1/contacts/map?bbox=minLng,minLat,maxLng,maxLat` (user-isolated, 500-cap) and `GET /api/v1/map/config` (surfaces the public Mapbox token).

Spec: `docs/superpowers/specs/2026-04-14-contact-map-view-design.md`
Plan: `docs/superpowers/plans/2026-04-14-contact-map-view.md`

## Before merging — prod config needed

Two env vars must be set on `/opt/pingcrm/.env` before the map becomes usable:

- `MAPBOX_SECRET_TOKEN` — server-side geocoding
- `MAPBOX_PUBLIC_TOKEN` — surfaced to browser (restrict in Mapbox dashboard to `pingcrm.sawinyh.com` + `localhost`)

Without them, geocoding no-ops gracefully and the `/map` page shows a "not configured" message; no crashes.

## Post-deploy

1. Run backfill: `docker compose exec -T backend python -c "from app.services.task_jobs.geocoding import backfill_all_contacts; backfill_all_contacts.delay()"`
2. Run the prod agent-browser smoke test (steps in the plan, Phase E Task 21).

## Test plan

- [x] Backend: migration up/down, geocoding service (happy/4xx/429/5xx retry), Celery task (happy/idempotent/clear/not-found sentinel), SA listener (insert/update/skip-unchanged), backfill filter, map bbox endpoint (in-bounds/user isolation/500-cap/bad bbox), map-config endpoint (present/empty/requires auth)
- [x] Frontend: 516 tests passing (nav + contact detail + existing suites)
- [x] Typecheck clean
- [x] CI guards (response_model / as-any baseline) pass
- [ ] Prod smoke test (after deploy + token config + backfill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)