### PR TITLE
fix(geocoding): register Celery tasks

### DIFF
--- a/backend/app/services/tasks.py
+++ b/backend/app/services/tasks.py
@@ -59,6 +59,10 @@ from app.services.task_jobs.whatsapp import (
     sync_whatsapp_backfill,
     check_whatsapp_sessions,
 )
+from app.services.task_jobs.geocoding import (
+    geocode_contact,
+    backfill_all_contacts,
+)
 
 __all__ = [
     # common
@@ -105,4 +109,7 @@ __all__ = [
     # whatsapp
     "sync_whatsapp_backfill",
     "check_whatsapp_sessions",
+    # geocoding
+    "geocode_contact",
+    "backfill_all_contacts",
 ]


### PR DESCRIPTION
Register geocode_contact and backfill_all_contacts in app.services.tasks so the Celery worker imports them and .delay() enqueues to a real consumer.