### PR TITLE
fix(settings): persist consecutive writes to priority/sync settings

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from sqlalchemy import Boolean, DateTime, String, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -48,8 +49,15 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    priority_settings: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    sync_settings: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # JSONB columns wrapped with MutableDict so SQLAlchemy detects in-place
+    # mutations (e.g. settings["k"] = v). Without this, reassigning the same
+    # dict reference is a no-op and writes silently don't persist.
+    priority_settings: Mapped[dict | None] = mapped_column(
+        MutableDict.as_mutable(JSONB), nullable=True
+    )
+    sync_settings: Mapped[dict | None] = mapped_column(
+        MutableDict.as_mutable(JSONB), nullable=True
+    )
     sync_2nd_tier: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False, server_default="true")
     linkedin_extension_paired_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -123,3 +123,39 @@ async def test_update_priority_accepts_boundary_values(
     assert data["high"] == 7
     assert data["medium"] == 180
     assert data["low"] == 365
+
+
+@pytest.mark.asyncio
+async def test_update_suggestion_prefs_persists_consecutive_writes(
+    client: AsyncClient, auth_headers: dict
+):
+    """Two consecutive PUTs must both persist.
+
+    Regression for a silent-write bug where the JSONB column wasn't wrapped
+    with MutableDict, so in-place mutations of the same dict reference were
+    not detected by SQLAlchemy and subsequent UPDATEs were no-ops.
+    """
+    # First save — works even with the bug because the column was NULL.
+    r1 = await client.put(
+        "/api/v1/settings/suggestions",
+        json={"dormancy_threshold_days": 730},
+        headers=auth_headers,
+    )
+    assert r1.status_code == 200
+    assert r1.json()["data"]["dormancy_threshold_days"] == 730
+
+    g1 = await client.get("/api/v1/settings/suggestions", headers=auth_headers)
+    assert g1.json()["data"]["dormancy_threshold_days"] == 730
+
+    # Second save — this is what regressed: same dict reference, so the
+    # change wasn't flagged and didn't persist.
+    r2 = await client.put(
+        "/api/v1/settings/suggestions",
+        json={"dormancy_threshold_days": 1095},
+        headers=auth_headers,
+    )
+    assert r2.status_code == 200
+    assert r2.json()["data"]["dormancy_threshold_days"] == 1095
+
+    g2 = await client.get("/api/v1/settings/suggestions", headers=auth_headers)
+    assert g2.json()["data"]["dormancy_threshold_days"] == 1095


### PR DESCRIPTION
## Summary

The User.priority_settings and User.sync_settings JSONB columns weren't wrapped with MutableDict, so SQLAlchemy didn't detect in-place mutations of the dict. The first PUT worked because the column transitioned from NULL to a fresh dict, but every subsequent PUT mutated the same dict reference and emitted no UPDATE — the change silently didn't persist.

User-visible symptom: changing the "Active window" select on /settings?tab=followup, leaving the page, and returning shows the original value.

## Fix

Wrap both columns with `MutableDict.as_mutable(JSONB)` so `__setitem__` / `update()` calls trigger SQLAlchemy's change tracking automatically. No migration needed — purely a Python-side wrapper. Same fix repairs `priority_settings` (priority thresholds) and `sync_settings` (per-platform sync settings) which had the same bug.

## Test plan

- [x] New regression test: two consecutive PUTs to /api/v1/settings/suggestions both persist (fails on the old model, passes on the new)
- [x] All 15 settings/sync API tests pass
- [ ] Manual verification on prod after deploy: change Active window, refresh, value sticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)