### PR TITLE
fix(meta): stable sidebar snippet hash + surface FB/IG in UI

### DIFF
--- a/backend/app/integrations/twitter.py
+++ b/backend/app/integrations/twitter.py
@@ -15,6 +15,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.integrations.twitter_contacts import (
+    _build_twitter_id_to_contact_map,
+    _cached_resolve_handles,
+)
 from app.integrations.twitter_auth import (
     _TOKEN_REFRESH_BUFFER_SECONDS,
     _refresh_and_retry,

--- a/backend/app/schemas/contact.py
+++ b/backend/app/schemas/contact.py
@@ -37,6 +37,10 @@ class ContactBase(BaseModel):
     linkedin_profile_id: str | None = None
     linkedin_headline: str | None = None
     linkedin_bio: str | None = None
+    facebook_id: str | None = None
+    facebook_name: str | None = None
+    instagram_id: str | None = None
+    instagram_username: str | None = None
     avatar_url: str | None = None
     birthday: str | None = None
     tags: list[str] = []
@@ -91,6 +95,10 @@ class ContactUpdate(BaseModel):
     linkedin_profile_id: str | None = None
     linkedin_headline: str | None = None
     linkedin_bio: str | None = None
+    facebook_id: str | None = None
+    facebook_name: str | None = None
+    instagram_id: str | None = None
+    instagram_username: str | None = None
     birthday: str | None = None
     tags: list[str] | None = None
     notes: str | None = None

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2043,7 +2043,7 @@
           "contacts"
         ],
         "summary": "Extract Bio",
-        "description": "Extract structured data from contact bios using AI.\n\nParses twitter_bio, telegram_bio, linkedin_bio/headline and the contact's\nname fields through Haiku to extract title, company, website, and\nnormalize name fields (e.g. \"Anders | LoopFi\" -> first: Anders, company: LoopFi).\nAlso updates the linked Organization record with extracted company details.",
+        "description": "Extract structured data from contact bios using AI.",
         "operationId": "extract_bio_api_v1_contacts__contact_id__extract_bio_post",
         "security": [
           {
@@ -6238,6 +6238,50 @@
             ],
             "title": "Linkedin Bio"
           },
+          "facebook_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Facebook Id"
+          },
+          "facebook_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Facebook Name"
+          },
+          "instagram_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Id"
+          },
+          "instagram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Username"
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -6598,6 +6642,50 @@
               }
             ],
             "title": "Linkedin Bio"
+          },
+          "facebook_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Facebook Id"
+          },
+          "facebook_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Facebook Name"
+          },
+          "instagram_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Id"
+          },
+          "instagram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Username"
           },
           "avatar_url": {
             "anyOf": [
@@ -7197,6 +7285,50 @@
               }
             ],
             "title": "Linkedin Bio"
+          },
+          "facebook_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Facebook Id"
+          },
+          "facebook_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Facebook Name"
+          },
+          "instagram_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Id"
+          },
+          "instagram_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instagram Username"
           },
           "birthday": {
             "anyOf": [

--- a/chrome-extension/background/meta-sync-utils.js
+++ b/chrome-extension/background/meta-sync-utils.js
@@ -30,6 +30,20 @@ function _metaDelay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+// ── Stable hash for sidebar snippets ─────────────────────────────────────────
+// Sidebar scrapes don't expose real message IDs, so derive a stable key from
+// the snippet itself. Re-syncs of the same snippet produce the same key,
+// letting the backend's raw_reference_id dedup catch them.
+
+async function _metaSnippetHash(text) {
+  const bytes = new TextEncoder().encode(String(text ?? ""));
+  const buf = await crypto.subtle.digest("SHA-1", bytes);
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 16);
+}
+
 // ── Messenger parsers ────────────────────────────────────────────────────────
 
 function _parseMetaConversations(raw) {

--- a/chrome-extension/background/sync-facebook.js
+++ b/chrome-extension/background/sync-facebook.js
@@ -204,19 +204,22 @@ async function _runFacebookSyncInner(apiUrl, token, force, result) {
       });
     }
 
-    // Build message from last conversation snippet
+    // Build message from last conversation snippet.
+    // The sidebar only exposes the last-message preview, not a real message ID.
+    // Derive message_id from sha1(snippet) so re-syncs of the same snippet
+    // produce the same key and dedupe on the backend.
     if (conv.snippet) {
       const now = Date.now();
-      const msgTimestamp = new Date().toISOString();
+      const snippetHash = await _metaSnippetHash(conv.snippet);
 
       messages.push({
-        message_id: `fb_sidebar_${conv.threadId}_${Math.floor(now / 60000)}`,
+        message_id: `fb_sidebar_${conv.threadId}_${snippetHash}`,
         conversation_id: conv.threadId,
         platform_id: conv.threadId,
         sender_name: conv.name,
         direction: "inbound", // sidebar shows their last message typically
         content_preview: conv.snippet.substring(0, 500),
-        timestamp: msgTimestamp,
+        timestamp: new Date().toISOString(),
         reactions: [],
         read_by: [],
       });

--- a/chrome-extension/background/sync-instagram.js
+++ b/chrome-extension/background/sync-instagram.js
@@ -202,12 +202,15 @@ async function _runInstagramSyncInner(apiUrl, token, force, result) {
       });
     }
 
-    // Build message from last DM snippet
+    // Build message from last DM snippet. Sidebar has no real message ID,
+    // so derive a stable key from sha1(snippet) — re-syncs of the same
+    // snippet produce the same key and dedupe on the backend.
     if (thread.snippet) {
       const now = Date.now();
+      const snippetHash = await _metaSnippetHash(thread.snippet);
 
       messages.push({
-        message_id: `ig_sidebar_${thread.threadId}_${Math.floor(now / 60000)}`,
+        message_id: `ig_sidebar_${thread.threadId}_${snippetHash}`,
         conversation_id: thread.threadId,
         platform_id: thread.threadId,
         sender_name: thread.name,

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PingCRM Companion",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Syncs LinkedIn, Facebook Messenger, Instagram DMs, and X mentions/bios to your PingCRM instance",
   "permissions": ["storage", "activeTab", "cookies", "scripting"],
   "host_permissions": ["https://www.linkedin.com/*", "http://localhost/*", "https://*/*", "https://www.facebook.com/*", "https://www.instagram.com/*", "https://x.com/*", "https://twitter.com/*"],

--- a/frontend/src/app/contacts/[id]/_components/details-panel.tsx
+++ b/frontend/src/app/contacts/[id]/_components/details-panel.tsx
@@ -466,6 +466,24 @@ export function DetailsPanel({
           linkPrefix=""
           copyable
         />
+        <InlineField
+          label="Facebook"
+          value={contact.facebook_id}
+          displayValue={contact.facebook_name ?? contact.facebook_id ?? undefined}
+          onSave={(v) => onSaveField("facebook_id", v)}
+          isLink
+          linkPrefix="https://facebook.com/"
+          copyable
+        />
+        <InlineField
+          label="Instagram"
+          value={contact.instagram_username}
+          displayValue={contact.instagram_username ? `@${contact.instagram_username}` : undefined}
+          onSave={(v) => onSaveField("instagram_username", v)}
+          isLink
+          linkPrefix="https://instagram.com/"
+          copyable
+        />
         <InlineListField
           label="Phone"
           values={contact.phones ?? []}

--- a/frontend/src/hooks/use-contacts.ts
+++ b/frontend/src/hooks/use-contacts.ts
@@ -24,6 +24,10 @@ export type Contact = {
   longitude?: number | null;
   birthday: string | null;
   linkedin_url: string | null;
+  facebook_id: string | null;
+  facebook_name: string | null;
+  instagram_id: string | null;
+  instagram_username: string | null;
   whatsapp_phone: string | null;
   avatar_url: string | null;
   tags: string[];

--- a/frontend/src/lib/api-types.d.ts
+++ b/frontend/src/lib/api-types.d.ts
@@ -671,11 +671,6 @@ export interface paths {
         /**
          * Extract Bio
          * @description Extract structured data from contact bios using AI.
-         *
-         *     Parses twitter_bio, telegram_bio, linkedin_bio/headline and the contact's
-         *     name fields through Haiku to extract title, company, website, and
-         *     normalize name fields (e.g. "Anders | LoopFi" -> first: Anders, company: LoopFi).
-         *     Also updates the linked Organization record with extracted company details.
          */
         post: operations["extract_bio_api_v1_contacts__contact_id__extract_bio_post"];
         delete?: never;
@@ -2259,6 +2254,14 @@ export interface components {
             linkedin_headline?: string | null;
             /** Linkedin Bio */
             linkedin_bio?: string | null;
+            /** Facebook Id */
+            facebook_id?: string | null;
+            /** Facebook Name */
+            facebook_name?: string | null;
+            /** Instagram Id */
+            instagram_id?: string | null;
+            /** Instagram Username */
+            instagram_username?: string | null;
             /** Avatar Url */
             avatar_url?: string | null;
             /** Birthday */
@@ -2352,6 +2355,14 @@ export interface components {
             linkedin_headline?: string | null;
             /** Linkedin Bio */
             linkedin_bio?: string | null;
+            /** Facebook Id */
+            facebook_id?: string | null;
+            /** Facebook Name */
+            facebook_name?: string | null;
+            /** Instagram Id */
+            instagram_id?: string | null;
+            /** Instagram Username */
+            instagram_username?: string | null;
             /** Avatar Url */
             avatar_url?: string | null;
             /** Birthday */
@@ -2520,6 +2531,14 @@ export interface components {
             linkedin_headline?: string | null;
             /** Linkedin Bio */
             linkedin_bio?: string | null;
+            /** Facebook Id */
+            facebook_id?: string | null;
+            /** Facebook Name */
+            facebook_name?: string | null;
+            /** Instagram Id */
+            instagram_id?: string | null;
+            /** Instagram Username */
+            instagram_username?: string | null;
             /** Birthday */
             birthday?: string | null;
             /** Tags */


### PR DESCRIPTION
## Summary

Two fixes, both surfaced from previously-uncommitted WIP that was left in the tree from earlier sessions.

### 1. Meta sidebar dedup (the actual bug)

Chrome extension scrapes Messenger and Instagram **sidebars** for last-message previews, but the sidebar exposes no real message ID. The old code used `Math.floor(now / 60000)` (minute-rounded timestamp) as the synthetic ID — so re-syncs in a different minute created duplicate Interaction rows.

Fix: replace with `sha1(snippet)` so re-syncs of the same snippet collapse on the backend's `raw_reference_id` dedup. New `_metaSnippetHash` helper in `meta-sync-utils.js`; both `sync-facebook.js` and `sync-instagram.js` adopt it.

### 2. Surface Facebook/Instagram in the contact UI

Migration `ad8670aa51dd_add_meta_facebook_instagram_fields` already added `facebook_id`, `facebook_name`, `instagram_id`, `instagram_username` columns to `contacts`. This PR exposes them through:

- `backend/app/schemas/contact.py` — `ContactBase` and `ContactUpdate`
- `frontend/src/hooks/use-contacts.ts` — typed `Contact` shape
- `frontend/src/lib/api-types.d.ts` + `backend/openapi.json` — regenerated
- `details-panel.tsx` — Facebook and Instagram `InlineField` rows in the contact panel

### 3. Twitter regression fix (separate commit)

PR #82 (lint cleanup) inadvertently removed a local import of `_build_twitter_id_to_contact_map` from `twitter.py` when extracting DM functions into `twitter_dms.py`. The function is still used by `sync_twitter_mentions` and `sync_twitter_replies` in `twitter.py`. Restored at module scope alongside `_cached_resolve_handles`. Caught by `test_twitter_bird_sync.py::test_mention_cursor_saved_after_sync` in the full backend sweep.

## Test plan

- [x] 26 contact API tests pass
- [x] 17 twitter bird-sync tests pass
- [x] Full backend pytest sweep (888 → all pass after twitter fix)
- [x] 531 frontend vitest tests pass
- [x] `npx tsc --noEmit` clean
- [x] `chrome-extension/manifest.json` bumped to 1.8.1 (extension code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)