### PR TITLE
fix(twitter): stop bird 429 storm from contact-update trigger

### DIFF
--- a/backend/app/api/contacts_routes/crud.py
+++ b/backend/app/api/contacts_routes/crud.py
@@ -249,13 +249,21 @@ async def update_contact(
         except Exception:
             logger.warning("Failed to clear bio_refresh cache for contact %s", contact_id, exc_info=True)
 
-    # Trigger background refresh when Twitter handle is added/changed
+    # Trigger background refresh when Twitter handle is added/changed.
+    # Scoped to THIS contact only — the old `poll_twitter_activity` dispatch
+    # scanned every contact's handle on every edit and caused bird 429 storms.
     if twitter_handle_changed:
         try:
-            from app.services.task_jobs.twitter import poll_twitter_activity
-            poll_twitter_activity.apply_async(args=[str(current_user.id)], countdown=3)
+            from app.services.task_jobs.twitter import refresh_contact_twitter_bio
+            refresh_contact_twitter_bio.apply_async(
+                args=[str(current_user.id), str(contact.id)],
+                countdown=3,
+            )
         except Exception:
-            logger.warning("Failed to dispatch poll_twitter_activity for user %s", current_user.id, exc_info=True)
+            logger.warning(
+                "Failed to dispatch refresh_contact_twitter_bio for contact %s",
+                contact.id, exc_info=True,
+            )
     return envelope(ContactResponse.model_validate(contact).model_dump())
 
 

--- a/backend/app/integrations/bird.py
+++ b/backend/app/integrations/bird.py
@@ -10,6 +10,7 @@ string to decide whether to surface a user-facing failure.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import shutil
@@ -19,6 +20,43 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _BIRD_TIMEOUT = 20  # seconds
+
+# Rate-gate: once bird returns 429 for a cookie set, skip further bird calls
+# for this many seconds. Mirrors the Telegram FloodWait pattern.
+_BIRD_RATE_GATE_TTL = 15 * 60  # 15 minutes
+
+
+def _gate_key(ct0: str) -> str:
+    """Per-cookie-set Redis key. Hash ct0 so the secret never appears in keys."""
+    digest = hashlib.sha1(ct0.encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"bird_rate_gate:{digest}"
+
+
+async def _is_rate_gated(ct0: str) -> bool:
+    """True iff this cookie set is currently rate-gated."""
+    if not ct0:
+        return False
+    try:
+        from app.core.redis import get_redis
+        return bool(await get_redis().get(_gate_key(ct0)))
+    except Exception:
+        logger.exception("bird _is_rate_gated: redis check failed")
+        return False
+
+
+async def _set_rate_gate(ct0: str, ttl_seconds: int = _BIRD_RATE_GATE_TTL) -> None:
+    """Mark this cookie set as rate-gated for *ttl_seconds*."""
+    if not ct0:
+        return
+    try:
+        from app.core.redis import get_redis
+        await get_redis().set(_gate_key(ct0), "1", ex=ttl_seconds)
+        logger.warning(
+            "bird rate-gate set for cookie %s (ttl=%ds) — bird calls will short-circuit",
+            _gate_key(ct0), ttl_seconds,
+        )
+    except Exception:
+        logger.exception("bird _set_rate_gate: redis write failed")
 
 
 @dataclass
@@ -65,9 +103,15 @@ async def _run_bird(*args: str, auth_token: str, ct0: str) -> BirdResult:
     injected as ``--auth-token`` / ``--ct0`` CLI flags before the subcommand
     so that concurrent per-user calls remain isolated.
 
+    Short-circuits without shelling out when this cookie set is currently
+    rate-gated (set by a previous 429 from bird).
+
     Returns a :class:`BirdResult` with ``data`` on success or ``error`` on
     failure.
     """
+    if await _is_rate_gated(ct0):
+        return BirdResult(data=None, error="bird rate-gated; skipping")
+
     bird_path = shutil.which("bird")
     if not bird_path:
         msg = "bird CLI not found on PATH — Twitter enrichment is unavailable"
@@ -109,6 +153,12 @@ async def _run_bird(*args: str, auth_token: str, ct0: str) -> BirdResult:
 
     if proc.returncode != 0:
         stderr_text = stderr.decode(errors="replace")[:200]
+        stdout_text = stdout.decode(errors="replace")[:200]
+        # bird prints "HTTP 429: Rate limit exceeded" to stdout/stderr when
+        # Twitter rate-limits the cookie set. Trip the gate so subsequent calls
+        # short-circuit until the window expires.
+        if "429" in stderr_text or "429" in stdout_text or "Rate limit" in stderr_text or "Rate limit" in stdout_text:
+            await _set_rate_gate(ct0)
         msg = f"bird {args[0]}: exit code {proc.returncode}: {stderr_text}"
         logger.warning(msg)
         return BirdResult(data=None, error=msg)

--- a/backend/app/services/task_jobs/twitter.py
+++ b/backend/app/services/task_jobs/twitter.py
@@ -206,3 +206,52 @@ def poll_twitter_all() -> dict:
 
     logger.info("poll_twitter_all: queued %d user(s) for activity + DMs.", len(user_ids))
     return {"queued": len(user_ids)}
+
+
+@shared_task(name="app.services.tasks.refresh_contact_twitter_bio", bind=True, max_retries=2, soft_time_limit=60, time_limit=90)
+def refresh_contact_twitter_bio(self, user_id: str, contact_id: str) -> dict:
+    """Fetch the Twitter bio for ONE contact via bird CLI.
+
+    Replaces the per-edit `poll_twitter_activity` dispatch that scanned
+    every contact's Twitter handle on every contact-update request — that
+    pattern caused bird 429 storms.
+
+    Args:
+        user_id: String UUID of the contact owner.
+        contact_id: String UUID of the specific contact to refresh.
+    """
+    async def _refresh(uid: uuid.UUID, cid: uuid.UUID) -> dict:
+        from app.services.bio_refresh import refresh_contact_bios
+
+        async with task_session() as db:
+            user_res = await db.execute(select(User).where(User.id == uid))
+            user = user_res.scalar_one_or_none()
+            if user is None:
+                return {"status": "user_not_found"}
+            contact_res = await db.execute(
+                select(Contact).where(
+                    Contact.id == cid,
+                    Contact.user_id == uid,
+                )
+            )
+            contact = contact_res.scalar_one_or_none()
+            if contact is None:
+                return {"status": "contact_not_found"}
+            changes = await refresh_contact_bios(contact, user, db)
+            await db.commit()
+            return {"status": "ok", "changes": changes}
+
+    try:
+        uid = uuid.UUID(user_id)
+        cid = uuid.UUID(contact_id)
+    except ValueError:
+        return {"status": "invalid_id"}
+
+    try:
+        return _run(_refresh(uid, cid))
+    except Exception as exc:
+        logger.exception(
+            "refresh_contact_twitter_bio failed",
+            extra={"provider": "twitter", "user_id": user_id, "contact_id": contact_id},
+        )
+        raise self.retry(exc=exc, countdown=120) from exc

--- a/backend/app/services/tasks.py
+++ b/backend/app/services/tasks.py
@@ -32,6 +32,7 @@ from app.services.task_jobs.twitter import (
     poll_twitter_activity,
     sync_twitter_dms_for_user,
     poll_twitter_all,
+    refresh_contact_twitter_bio,
 )
 from app.services.task_jobs.google import (
     sync_google_contacts_for_user,
@@ -93,6 +94,7 @@ __all__ = [
     "poll_twitter_activity",
     "sync_twitter_dms_for_user",
     "poll_twitter_all",
+    "refresh_contact_twitter_bio",
     # google
     "sync_google_contacts_for_user",
     "sync_google_calendar_for_user",

--- a/backend/tests/test_bird_rate_gate.py
+++ b/backend/tests/test_bird_rate_gate.py
@@ -1,0 +1,92 @@
+"""Tests for the bird rate-gate (Fix 2 for the 429 storm)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.integrations.bird import (
+    _gate_key,
+    _is_rate_gated,
+    _set_rate_gate,
+    fetch_user_tweets_bird,
+)
+
+
+def test_gate_key_hashes_ct0():
+    """Gate key must hash ct0 — the cookie should never appear in the key."""
+    key = _gate_key("secret_cookie_value")
+    assert "secret_cookie_value" not in key
+    assert key.startswith("bird_rate_gate:")
+    assert len(key.split(":", 1)[1]) == 16
+
+
+def test_gate_key_stable():
+    """Same ct0 should produce the same key (so the gate persists across calls)."""
+    assert _gate_key("foo") == _gate_key("foo")
+    assert _gate_key("foo") != _gate_key("bar")
+
+
+@pytest.mark.asyncio
+async def test_rate_gate_set_and_check():
+    """Setting the gate makes _is_rate_gated return True for the same ct0."""
+    fake_redis = AsyncMock()
+    fake_redis.get = AsyncMock(side_effect=[None, b"1"])
+    fake_redis.set = AsyncMock()
+    with patch("app.core.redis.get_redis", return_value=fake_redis):
+        assert await _is_rate_gated("ct0_value") is False
+        await _set_rate_gate("ct0_value")
+        assert await _is_rate_gated("ct0_value") is True
+    fake_redis.set.assert_awaited_once()
+    set_args = fake_redis.set.await_args
+    assert set_args.args[0] == _gate_key("ct0_value")
+    assert set_args.kwargs["ex"] == 15 * 60
+
+
+@pytest.mark.asyncio
+async def test_run_bird_short_circuits_when_gated():
+    """If the gate is set, _run_bird returns an error without shelling out."""
+    fake_redis = AsyncMock()
+    fake_redis.get = AsyncMock(return_value=b"1")  # gated
+    with patch("app.core.redis.get_redis", return_value=fake_redis), \
+         patch("asyncio.create_subprocess_exec", side_effect=AssertionError(
+             "should not exec when gated"
+         )):
+        tweets, err = await fetch_user_tweets_bird(
+            "anyhandle", auth_token="t", ct0="ct0_value",
+        )
+    assert tweets == []
+    assert err is not None
+    assert "rate-gated" in err
+
+
+@pytest.mark.asyncio
+async def test_run_bird_trips_gate_on_429():
+    """A bird exit-code-1 with '429' in stderr should set the gate."""
+    fake_redis = AsyncMock()
+    fake_redis.get = AsyncMock(return_value=None)  # not gated initially
+    fake_redis.set = AsyncMock()
+
+    # Mock asyncio.create_subprocess_exec to return a proc whose stderr has the 429 marker
+    fake_proc = AsyncMock()
+    fake_proc.returncode = 1
+    fake_proc.communicate = AsyncMock(return_value=(
+        b"",
+        b"\xe2\x9d\x8c Failed to fetch tweets: HTTP 429: Rate limit exceeded\n",
+    ))
+
+    with patch("app.core.redis.get_redis", return_value=fake_redis), \
+         patch("shutil.which", return_value="/usr/bin/bird"), \
+         patch(
+             "asyncio.create_subprocess_exec",
+             AsyncMock(return_value=fake_proc),
+         ):
+        tweets, err = await fetch_user_tweets_bird(
+            "anyhandle", auth_token="t", ct0="ct0_value",
+        )
+
+    assert tweets == []
+    assert err is not None
+    fake_redis.set.assert_awaited_once()
+    set_call = fake_redis.set.await_args
+    assert set_call.args[0] == _gate_key("ct0_value")


### PR DESCRIPTION
## Summary

Eliminates the 194-calls-in-48h bird 429 storm visible in prod worker logs.

**Root cause:** Updating any contact's Twitter handle dispatched `poll_twitter_activity` for the **entire user** — a task that scans every contact's handle via `bird user-tweets` (5-way concurrent). Three contact edits in two minutes produced three parallel full-account sweeps. The cookie set hit Twitter's rate limit and started returning 429 to every bird call.

## Two fixes

### 1. Single-contact bio refresh on contact edit

Replace the full-account `poll_twitter_activity.apply_async(args=[user_id])` in `contacts_routes/crud.py` with a new `refresh_contact_twitter_bio(user_id, contact_id)` Celery task that wraps the existing `refresh_contact_bios` helper for one specific contact.

Per-edit bird calls: **65 → 1.**

### 2. Bird rate-gate in `_run_bird`

Mirrors the Telegram FloodWait pattern. When bird's subprocess output contains `429` or `Rate limit`, set a Redis flag `bird_rate_gate:<sha1(ct0)[:16]>` with 15-min TTL. Subsequent `_run_bird` calls check the gate first and short-circuit before shelling out. ct0 is hashed so the cookie never appears in keys/logs.

Belt-and-suspenders against future over-eager callers.

## Test plan

- [x] 5 new tests in `test_bird_rate_gate.py` covering gate key hashing, set+check, short-circuit, 429 detection
- [x] 17 existing `test_twitter_bird_sync.py` tests pass
- [x] 76 bird + Twitter tests total pass (`test_bird_*`, `test_twitter_*`)
- [x] 26 contacts API tests pass — update endpoint still works
- [ ] After deploy: confirm 429 rate drops in prod worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)