### PR TITLE
fix(identity): wrap useSearchParams in Suspense

### DIFF
--- a/frontend/src/app/identity/page.tsx
+++ b/frontend/src/app/identity/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   X,
@@ -40,6 +40,17 @@ function Toast({ message, onDismiss }: { message: string; onDismiss: () => void 
 }
 
 export default function IdentityPage() {
+  // Wrap in Suspense because useSearchParams() in IdentityPageContent forces
+  // a CSR bailout during static prerender. Without this boundary, `next build`
+  // fails on the /identity route.
+  return (
+    <Suspense fallback={<div className="min-h-screen bg-stone-50 dark:bg-stone-950" />}>
+      <IdentityPageContent />
+    </Suspense>
+  );
+}
+
+function IdentityPageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const tab: "contacts" | "orgs" =


### PR DESCRIPTION
Unbreaks `next build` for the /identity page.

The org-dedup work added a Contacts|Orgs tab toggle backed by `useSearchParams()`. That hook triggers a CSR bailout during static prerender, so the production frontend build failed on /identity. PR #84's CI caught it (direct main-pushes only run the pre-push test hook, not next build).

Split into:
- `IdentityPage` — thin Suspense wrapper
- `IdentityPageContent` — the body that calls useSearchParams

🤖 Generated with [Claude Code](https://claude.com/claude-code)