### PR TITLE
docs: clarify local Docker setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@ Thanks for your interest in contributing! Here's how to get started.
 
 2. **Start the database and Redis**
    ```bash
-   docker-compose up -d db redis
+   cp .env.docker.example .env  # edit POSTGRES_PASSWORD and SECRET_KEY
+   docker compose up -d postgres redis
    ```
 
 3. **Backend**

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Point Claude Code, Cursor, Codex, or any coding agent at [`AGENT_SETUP.md`](AGEN
 ```bash
 git clone https://github.com/sneg55/pingcrm.git
 cd pingcrm
-cp backend/.env.example backend/.env  # edit values
+cp backend/.env.example backend/.env  # edit backend/integration values
+cp .env.docker.example .env           # edit POSTGRES_PASSWORD and SECRET_KEY
 docker compose up -d
 ```
 

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -26,9 +26,10 @@ Spin up PostgreSQL, Redis, the backend, the frontend, and the Celery worker with
 ```bash
 # Configure environment variables
 cp backend/.env.example backend/.env
+cp .env.docker.example .env
 
-# Set required variables (edit backend/.env or export in your shell)
-export POSTGRES_PASSWORD=your_secure_password
+# Set required variables used by Docker Compose interpolation
+# Edit .env and replace POSTGRES_PASSWORD and SECRET_KEY.
 
 # Start all services
 docker compose up
@@ -41,10 +42,10 @@ The dev compose file (`docker-compose.yml`) builds images from local source and 
 
 ### Environment variables
 
-Docker Compose reads from `./backend/.env` (via `env_file`) and also accepts overrides through shell environment variables. At minimum, set:
+Docker Compose reads service runtime variables from `./backend/.env` (via `env_file`). It also interpolates root-level Compose variables from `./.env` or the shell before services start. At minimum, set:
 
-- `POSTGRES_PASSWORD` -- required, used by both the `postgres` and `backend` services
-- `SECRET_KEY` -- required, generate with `python -c "import secrets; print(secrets.token_urlsafe(64))"`
+- `POSTGRES_PASSWORD` -- required in `./.env` or the shell; used by both the `postgres` and `backend` services
+- `SECRET_KEY` -- required in `./.env`, `./backend/.env`, or the shell; generate with `python -c "import secrets; print(secrets.token_urlsafe(64))"`
 
 All other integration credentials (`GOOGLE_CLIENT_ID`, `TWITTER_CLIENT_ID`, etc.) are passed through as optional environment variables. Skip ahead to [Platform Credentials](#3-platform-credentials) to fill them in.
 

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -45,7 +45,7 @@ The dev compose file (`docker-compose.yml`) builds images from local source and 
 Docker Compose reads service runtime variables from `./backend/.env` (via `env_file`). It also interpolates root-level Compose variables from `./.env` or the shell before services start. At minimum, set:
 
 - `POSTGRES_PASSWORD` -- required in `./.env` or the shell; used by both the `postgres` and `backend` services
-- `SECRET_KEY` -- required in `./.env`, `./backend/.env`, or the shell; generate with `python -c "import secrets; print(secrets.token_urlsafe(64))"`
+- `SECRET_KEY` -- required in `./.env` or the shell; generate with `python -c "import secrets; print(secrets.token_urlsafe(64))"`
 
 All other integration credentials (`GOOGLE_CLIENT_ID`, `TWITTER_CLIENT_ID`, etc.) are passed through as optional environment variables. Skip ahead to [Platform Credentials](#3-platform-credentials) to fill them in.
 


### PR DESCRIPTION
## What changed

- Update the README Docker quickstart to create both `backend/.env` and root `.env`.
- Fix the CONTRIBUTING support-service command to use the actual `postgres` service name.
- Clarify in the setup guide which env file is used by Compose interpolation vs service runtime env.

## Why

A fresh checkout currently fails before containers start if a user follows the README exactly: Compose needs root-level `POSTGRES_PASSWORD`/`SECRET_KEY`, and it also requires `backend/.env` because of the service `env_file`. The old contributing command also referenced `db`, but the service is named `postgres`.

## How to test

- `cp backend/.env.example backend/.env && cp .env.docker.example .env && docker compose config`
- `npm run build` from `docs/`

I removed the temporary ignored env files after validating.