### PR TITLE
docs: sync feature docs with current implementation

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -44,14 +44,16 @@ title: Technical Architecture
 
 | File | Lines | Role |
 |------|-------|------|
-| `integrations/telegram.py` | ~800 | Telegram DM/bio sync |
-| `integrations/telegram_transport.py` | ~200 | Telethon client lifecycle |
+| `integrations/telegram.py` | ~300 | Telegram DM/bio sync |
+| `integrations/telegram_transport.py` | ~85 | Telethon client lifecycle |
 | `integrations/telegram_helpers.py` | ~150 | Contact resolution helpers |
 | `integrations/telegram_groups.py` | ~250 | Group member sync |
-| `integrations/twitter.py` | ~700 | Twitter DM/mention/reply sync |
-| `integrations/twitter_auth.py` | ~160 | OAuth 2.0 PKCE token management |
-| `services/followup_engine.py` | ~750 | AI follow-up suggestion generation |
+| `integrations/twitter.py` | ~470 | Twitter DM/mention/reply sync |
+| `integrations/twitter_auth.py` | ~200 | OAuth 2.0 PKCE token management |
+| `services/followup_engine.py` | ~490 | AI follow-up suggestion generation |
 | `services/scoring.py` | ~200 | Relationship score calculation |
+
+Telegram sync logic is split across `telegram_bio_sync.py`, `telegram_chat_sync.py`, and `telegram_chat_batch.py`.
 
 ---
 
@@ -121,7 +123,8 @@ backend/app/
 All endpoints return a typed generic envelope. This provides a consistent contract for the frontend:
 
 ```python
-from pydantic import BaseModel, Generic, TypeVar
+from typing import Generic, TypeVar
+from pydantic import BaseModel
 
 T = TypeVar("T")
 
@@ -201,7 +204,7 @@ PostgreSQL with UUID primary keys throughout. Key models and their relationships
 
 **Contact** -- `full_name`, `emails[]` (PostgreSQL ARRAY with GIN index), `phones[]`, `company`, `organization_id`, `twitter_handle`, `twitter_bio`, `telegram_username`, `telegram_bio`, `linkedin_url`, `relationship_score` (0-10), `interaction_count`, `priority_level` (high/medium/low/archived), `tags[]`, `last_interaction_at`, `last_followup_at`, `birthday`.
 
-**Interaction** -- `contact_id`, `platform` (email/telegram/twitter/linkedin), `direction` (inbound/outbound), `content_preview`, `occurred_at`.
+**Interaction** -- `contact_id`, `platform` (email/telegram/twitter/linkedin), `direction` (inbound/outbound), `content_preview`, `occurred_at`, `call_type` (call category, e.g. voice/video), `duration_seconds` (call length).
 
 **FollowUpSuggestion** -- `contact_id`, `trigger_type` (time_based/event_based/scheduled/birthday/dormant_*), `suggested_message`, `suggested_channel`, `status` (pending/snoozed/dismissed/completed), `pool` (A/B), `snooze_until`.
 
@@ -237,10 +240,11 @@ Celery with Redis as both broker and result backend. Tasks use JSON serializatio
 | `refresh_org_stats` | Hourly (:30) | Refresh `organization_stats_mv` materialized view |
 | `reactivate_snoozed_suggestions` | Hourly (:00) | Un-snooze suggestions past their `snooze_until` |
 | `send_weekly_digests` | Monday 09:00 UTC | Email weekly networking digest |
-| `recheck_telegram_bios` | Every 3 days | Re-check Telegram bios for changes |
+| `recheck_telegram_bios_all` | Every 3 days | Re-check Telegram bios for changes |
 | `cleanup_stale_telegram_locks` | Hourly (:15) | Remove stale Telegram rate-limit locks |
 | `scan_meeting_preps` | Every 10 minutes | Scan upcoming Calendar meetings and email pre-meeting prep briefs |
 | `check_whatsapp_sessions` | Daily 01:00 UTC | Verify WhatsApp sidecar sessions are still connected |
+| `check_for_updates` | Every 6 hours (:15) | Check GitHub for new PingCRM releases |
 
 ### Task Safety
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -31,7 +31,7 @@ cd frontend && npm test
 
 ## Pre-push hook
 
-`.githooks/pre-push` runs the test suite (and the API-doc / response-model guards) before any push. It uses `backend/.venv`'s Python, so any new test dependency added to `requirements-test.txt` must also be installed in that venv:
+`.githooks/pre-push` runs the backend test suite (pytest, which includes the API-doc guard via test_api_doc.py), the frontend type-check (tsc), lint (next lint), and tests (vitest) before any push. The response-model guard (scripts/check_response_models.py) is a separate CI/manual check, not run by the hook. It uses `backend/.venv`'s Python, so any new test dependency added to `requirements-test.txt` must also be installed in that venv:
 
 ```bash
 cd backend && source .venv/bin/activate && pip install -r requirements-test.txt

--- a/docs/docs/features/contacts.md
+++ b/docs/docs/features/contacts.md
@@ -18,16 +18,21 @@ The `/contacts` page displays all contacts in a searchable, sortable, paginated 
 - **Full-text search** across contact names, emails, companies, notes, and social handles. A leading `@` is ignored, so `@username` and `username` find the same contacts. Results are ranked by relevance: exact name prefix matches rank highest, followed by partial name matches, company/title matches, social handle matches, then other fields.
 - **Filter by tags** to narrow results to specific groups.
 - **Filter by source** (Gmail, Telegram, Twitter, LinkedIn, CSV import, manual entry).
-- **Filter by relationship score** range.
-- **Filter by priority level** (high, medium, low, archived).
+- **Filter by relationship score** tier: strong (8-10), active (4-7), or dormant (0-3).
+- **Filter by priority level** (high, medium, low). Archived contacts are excluded by default and shown via a separate archived toggle.
 
 ### Sorting
 
 The list can be sorted by:
 
-- Name (alphabetical)
-- Relationship score (highest or lowest first)
-- Date added or last interaction date
+- Relationship score (default)
+- Date added
+- Last interaction
+- Activity (interaction count)
+- Company (alphabetical)
+- Upcoming birthday
+- Priority level
+- Most overdue
 
 ### Pagination
 
@@ -83,14 +88,12 @@ A visual badge displays the contact's computed relationship score, giving you an
 
 ### Message Composer
 
-Send messages directly from the contact detail page. Supported channels:
+The composer uses AI to draft context-aware messages for any channel, based on the contact's profile and interaction history. Direct in-app sending, however, is currently supported for **Telegram only**:
 
-- **Email** (via connected Gmail account)
-- **Telegram**
-- **Twitter DM**
-- **LinkedIn** (via Chrome extension)
-
-The composer uses AI to draft context-aware messages based on the contact's profile and interaction history.
+- **Telegram** -- drafted messages are sent directly through this endpoint.
+- **Email** -- send the draft from your own Gmail client; it is logged to the timeline via BCC addressing rather than sent through this endpoint.
+- **LinkedIn** -- messages are sent via the Chrome extension, not through this endpoint.
+- **Twitter DM** -- sending is not yet supported.
 
 ![Message composer drafting an AI-suggested message](/img/screenshots/contacts/detail-composer.png)
 

--- a/docs/docs/features/dashboard.md
+++ b/docs/docs/features/dashboard.md
@@ -11,7 +11,7 @@ The `/dashboard` page is the daily-driver view: stat cards at the top, follow-up
 
 ## Stat Cards
 
-Three counters at the top of the page, each with a week-over-week trend arrow when prior data is available:
+Three counters at the top of the page. Active relationships and Interactions this week each show a week-over-week trend arrow when prior data is available; Total contacts has no trend arrow.
 
 - **Total contacts** — every contact in the CRM, archived and active.
 - **Active relationships** — sum of contacts in the `active` and `strong` score buckets. The trend compares against the same value seven days ago.
@@ -23,7 +23,7 @@ When a fresh account has zero contacts, the stat cards are replaced with an inli
 
 Up to five pending suggestions from the follow-up engine, each rendered as an expandable card. Click a card to reveal the AI-drafted message inline; from there you can:
 
-- **Send** through the suggested channel (email, Telegram, Twitter, LinkedIn).
+- **Send** through the suggested channel (email, Telegram, or Twitter).
 - **Snooze** for 2 weeks, 1 month, or 3 months.
 - **Dismiss** to remove the suggestion.
 

--- a/docs/docs/features/gmail.md
+++ b/docs/docs/features/gmail.md
@@ -11,15 +11,16 @@ PingCRM connects to Gmail via OAuth 2.0 with Google, syncing email threads, cont
 
 The Gmail integration uses standard Google OAuth 2.0. After granting access on the Google consent screen, PingCRM stores a refresh token to maintain access without repeated sign-in. Multi-account support allows connecting more than one Gmail address.
 
+> **Setup note:** The Google OAuth consent screen must be published **"In production."** In **"Testing"** mode, Google expires refresh tokens after 7 days, which repeatedly breaks Gmail, Calendar, and Contacts sync.
+
 ![Gmail section in Settings](/img/screenshots/gmail/settings-section.png)
 
 ## Email Sync
 
 Individual email messages are imported as interactions. Each message captures:
 
-- **Sender and recipients** -- mapped to existing contacts or used to create new ones.
+- **Sender and recipients** -- matched to existing contacts by email address (or BCC hash). Email sync does not create new contacts; messages with no matching contact are skipped.
 - **Direction** -- inbound (contact sent to you) or outbound (you sent to contact), per message.
-- **Subject line** -- prepended to the message snippet for context.
 - **Timestamps** -- sent times for accurate timeline ordering.
 - **Body snippets** -- a preview of the email content without storing full message bodies.
 

--- a/docs/docs/features/identity.md
+++ b/docs/docs/features/identity.md
@@ -7,6 +7,8 @@ title: Identity Resolution
 
 The **Identity Resolution** page (`/identity`) detects and merges duplicate contacts that represent the same person across different platforms. PingCRM uses a multi-tier matching system to surface candidates, from deterministic exact matches to probabilistic scoring.
 
+The page has two tabs: **Contacts** (covered below) and **Organizations**, which surfaces duplicate organizations for review and merge using the same compare-and-merge workflow.
+
 ![Identity resolution queue](/img/screenshots/identity/queue.png)
 
 ## Tier 1: Deterministic Matching
@@ -35,7 +37,7 @@ When no exact identifier overlap exists, PingCRM computes a weighted similarity 
 | Username similarity | 10% |
 | Mutual signals (shared groups, common connections) | 10% |
 
-A combined score **above 85%** triggers an automatic merge. Scores below that threshold are surfaced for manual review.
+A combined score **above 85%** triggers an automatic merge. Scores between 70% and 85% are surfaced for manual review; scores below 70% are discarded.
 
 ### Guards
 
@@ -64,4 +66,4 @@ For each pair, you can:
 
 ## On-Demand Scan
 
-Click the **Scan** button on the Identity Resolution page to trigger a fresh duplicate detection pass across all contacts. This is useful after a large import or platform sync. The scan runs as a background task, and you will receive a notification when new matches are found.
+Click the **Scan for duplicates** button on the Identity Resolution page to run a fresh duplicate detection pass across all contacts — useful after a large import or platform sync. The scan runs synchronously and returns its results inline (matches found / auto-merged / pending review); it is not a background job and produces no notification.

--- a/docs/docs/features/linkedin.md
+++ b/docs/docs/features/linkedin.md
@@ -38,7 +38,7 @@ Messages are fetched via LinkedIn's Voyager GraphQL API, called directly from th
 
 On each sync the extension reads your LinkedIn session cookies from the browser, fetches conversations sorted by most-recent activity, and stops paginating once it reaches messages already seen in a previous sync (the **watermark**). Parsed results are pushed to the backend; LinkedIn cookies are never included.
 
-A **2-hour throttle** prevents excessive syncs during a browsing session. The popup's **Sync Now** button bypasses the throttle for an immediate sync.
+A **15-minute throttle** prevents excessive syncs during a browsing session. The popup's **Sync Now** button bypasses the throttle for an immediate sync.
 
 ## What Gets Synced
 
@@ -58,12 +58,10 @@ The extension syncs contacts you have **LinkedIn conversations** with. If you've
 
 When you open a LinkedIn message composer, the extension injects two small buttons into the toolbar:
 
-- **P (Pull)** — fetches your current pending follow-up suggestions for the contact whose conversation is open and displays them in a compact overlay above the composer.
-- **R (Regenerate)** — asks the backend to generate a fresh AI-drafted message for that suggestion, then updates the overlay with the new text.
+- **P (Pull)** — pastes the current pending suggestion's draft directly into the LinkedIn composer. This button is hidden when no pending suggestion exists.
+- **R (Regenerate)** — regenerates the AI draft and replaces the composer text with the new version.
 
-Clicking a suggestion in the overlay pastes it directly into the composer via a simulated keyboard event, so the LinkedIn send button activates normally. Both buttons use the extension's scoped JWT (`aud: pingcrm-extension`) to authenticate against the same `/api/v1/suggestions` endpoints used by the web app.
-
-The overlay is injected into LinkedIn's shadow DOM alongside the compose area and is removed automatically when the composer closes.
+The draft is inserted into the composer via a simulated paste event, so the LinkedIn send button activates normally. Both buttons use the extension's scoped JWT (`aud: pingcrm-extension`) to authenticate against the same `/api/v1/suggestions` endpoints used by the web app.
 
 ## Extension Architecture
 
@@ -72,7 +70,7 @@ The extension is built from two main pieces:
 - **Content script** — monitors the LinkedIn page for compose areas inside LinkedIn's shadow DOM. When a compose area appears, it injects the P and R buttons and manages the suggestion overlay lifecycle.
 - **Service worker** — handles sync logic: reads LinkedIn session cookies, calls the Voyager GraphQL API to fetch conversations and profiles, resolves a contact by matching the Voyager member ID or profile slug against the backend, and pushes parsed results to `/api/v1/linkedin/push`.
 
-When the **P** button is clicked, the content script sends a message to the service worker, which calls `/api/v1/suggestions` with the extension JWT and returns suggestions filtered to the current contact. The **R** button calls `/api/v1/suggestions/{id}/regenerate`. Text is inserted into the composer via a `paste` event simulation so LinkedIn's React input detects the change correctly.
+When the composer toolbar is detected, the content script asks the service worker for the pending suggestion for that contact (via `/api/v1/suggestions`); the P button then pastes that cached draft. The R button calls `/api/v1/suggestions/{id}/regenerate`. Text is inserted into the composer via a `paste` event simulation so LinkedIn's React input detects the change correctly.
 
 ## Profile Backfill
 
@@ -99,7 +97,7 @@ LinkedIn session cookies (`li_at` and `JSESSIONID`) are read fresh from your bro
 
 | Trigger | Behavior |
 |---|---|
-| Any LinkedIn page visit | Syncs if more than 2 hours have passed since the last sync |
+| Any LinkedIn page visit | Syncs if more than 15 minutes have passed since the last sync |
 | Manual "Sync Now" (popup) | Syncs immediately, no throttle |
 
 Sync is purely event-driven — no background alarms or scheduled tasks are needed. If your LinkedIn session expires, the popup shows a prompt to visit linkedin.com so the extension can pick up fresh cookies automatically on your next page visit.

--- a/docs/docs/features/map.md
+++ b/docs/docs/features/map.md
@@ -26,7 +26,7 @@ If a contact's location couldn't be geocoded (free-form text like a URL, emoji, 
 
 ## Viewport sidebar
 
-The right-hand sidebar lists contacts currently in view, sorted by relationship score (highest first). Moving or zooming the map refreshes the list automatically (debounced ~250ms).
+The right-hand sidebar lists contacts currently in view, sorted by relationship score (highest first). Moving or zooming the map refreshes the list automatically once the pan/zoom gesture ends (Mapbox moveend).
 
 Each row shows the contact's avatar, name, and score. Clicking a row opens the full contact page.
 
@@ -34,7 +34,7 @@ When a metro has more than 500 contacts in view, the sidebar shows a "Showing 50
 
 ## Clustering
 
-Zoomed-out views collapse nearby pins into numbered cluster bubbles. Clicking a cluster zooms in and breaks it apart. Cluster radius is 50 pixels, and clusters disappear at zoom level 14+.
+Zoomed-out views collapse nearby pins into numbered cluster bubbles. Clicking a cluster zooms in and breaks it apart. Cluster radius is 50 pixels, and clusters stop forming above zoom level 14 (individual pins from zoom 15).
 
 ![Cluster bubbles at zoomed-out view](/img/screenshots/map/cluster.png)
 
@@ -53,7 +53,7 @@ The task is idempotent: it skips contacts whose stored `geocoded_location` alrea
 |---|---|---|
 | 200 with a match | `latitude`, `longitude`, `geocoded_location`, `geocoded_at` all set | Pin rendered on map |
 | 200 with zero results | `geocoded_at` set, lat/lng null | Contact hidden from map; no retry until location changes |
-| 4xx | Same as zero results | Silently dropped; logged at info level |
+| 4xx | Same as zero results | Dropped; logged at warning (provider) + info (task) |
 | 429 (rate limit) | -- | Task re-queued with exponential backoff |
 | 5xx / timeout | -- | Retried up to 3 times inside the service, then Celery retry |
 

--- a/docs/docs/features/notifications.md
+++ b/docs/docs/features/notifications.md
@@ -13,11 +13,11 @@ The **Notifications** page (`/notifications`) is the central feed for system eve
 
 PingCRM generates notifications for the following events:
 
-- **Sync completion** -- confirms that a platform sync (Gmail, Telegram, Twitter, LinkedIn) finished successfully, including counts of new or updated records.
+- **Sync completion** -- confirms that a platform sync (Gmail, Telegram, Twitter) finished successfully, including counts of new or updated records.
 - **Sync failure** -- alerts when a sync could not complete, with error details.
 - **New suggestions** -- notifies when the follow-up engine produces new outreach suggestions.
-- **Bio change detections** -- fires when a monitored Twitter contact updates their bio, often indicating a job change or new venture.
-- **Identity matches** -- surfaces newly discovered duplicate contact candidates from the identity resolution engine.
+- **Bio change detections** -- fires when a monitored Twitter or Telegram contact updates their bio, often indicating a job change or new venture.
+- **Auto-tagging** -- reports when an automatic LLM tagging run finishes (or fails).
 - **Rate limit alerts** -- warns when a platform API rate limit has been hit, with estimated recovery time.
 - **Connection expired** -- alerts when a platform OAuth token has expired and needs re-authorization.
 - **Meeting prep re-auth** -- prompts re-authorization when the `gmail.send` scope is needed for pre-meeting prep emails.
@@ -47,5 +47,5 @@ The notification feed supports the following filter tabs:
 | All | Every notification, read and unread |
 | Unread | Only notifications not yet marked as read |
 | Suggestions | Follow-up suggestions from the AI engine |
-| Events | Bio changes, identity matches, and other contact events |
+| Events | Bio changes and other contact events |
 | System | Sync completions, sync failures, and rate limit alerts |

--- a/docs/docs/features/suggestions.md
+++ b/docs/docs/features/suggestions.md
@@ -19,7 +19,7 @@ Four independent triggers feed into Pool A. A contact only needs to match **one*
 
 | Trigger | Condition | Example |
 |---|---|---|
-| **Time-based** | No interaction in 90+ days, score > 0 | "Haven't talked to Alex in 3 months" |
+| **Time-based** | No interaction within the contact's priority interval (high 30d / medium 60d / low 180d), relationship score below 4 | "Haven't talked to Alex in 3 months" |
 | **Event-based** | DetectedEvent in last 7 days, confidence > 70% | Bio change, tweet about fundraising |
 | **Scheduled** | Past the priority interval since last follow-up | Medium priority set to 60 days, last follow-up was 65 days ago |
 | **Birthday** | Birthday in next 3 days | High priority (1500), bypasses dormancy filter |
@@ -32,13 +32,13 @@ Surfaces contacts you've lost touch with but had meaningful past engagement. Thr
 
 | Trigger | Condition |
 |---|---|
-| **B1 — Deep dormant** | No interaction in 365+ days, 2+ past interactions, score >= 3, history spans 30+ days |
-| **B2 — Mid dormant** | No interaction in 180-365 days, 3+ past interactions, score >= 4 |
-| **B3 — Event revival** | Dormant 180+ days but had a recent detected event (job change, etc.) |
+| **B1 — Deep dormant** | No interaction in 365 days to 5 years, score > 0, and (5+ past interactions OR score >= 5) |
+| **B2 — Mid dormant** | No interaction in 365 days to 3 years, score > 0, 2+ past interactions |
+| **B3 — Event revival** | Dormant past the threshold (default 365+ days) but had a detected event in the last 14 days (job change, etc.) |
 
 ### Cooldowns and Guards
 
-All triggers respect these guards — **including event-based triggers**:
+These guards apply broadly — **including event-based triggers**. Note the **interaction cooldown** is an interaction-recency filter that the birthday trigger is exempt from:
 
 | Guard | Rule |
 |---|---|
@@ -46,10 +46,10 @@ All triggers respect these guards — **including event-based triggers**:
 | **Follow-up cooldown** | Skip if last follow-up suggestion was within **14 days** |
 | **Already queued** | Skip if a pending or snoozed suggestion already exists |
 | **Archived** | Skip archived contacts |
-| **2nd-tier** | Skip contacts labelled "2nd-tier" |
-| **No channel** | Skip contacts with no email, Telegram, or Twitter handle |
-| **Ghosting (3+)** | Skip if last 3+ consecutive interactions are all outbound with no reply |
-| **Ghosting (2)** | Reduce priority by 50% if last 2 consecutive interactions are outbound |
+| **2nd-tier** | Skip contacts labelled "2nd tier" |
+| **No channel** | Skip contacts with no email, Telegram, Twitter, or LinkedIn |
+| **Ghosting (3+)** | Skip if last 3+ consecutive interactions are all outbound with no reply and the most recent was within 30 days |
+| **Ghosting (2)** | Reduce priority by 50% if last 2 consecutive interactions are outbound and the most recent was within 30 days |
 | **Unread outbound** | Skip if last outbound Telegram message hasn't been read by recipient |
 | **Read no reply** | Boost priority +100 if last outbound was read but no inbound reply |
 
@@ -64,17 +64,17 @@ Within each pool, candidates are ranked by priority score:
 
 ### Relationship Score
 
-The relationship score (0-10) is computed from five weighted dimensions plus a tenure bonus:
+The relationship score (0-10) is an additive sum of integer point ranges across several dimensions plus a tenure bonus, capped at 10:
 
-| Dimension | Weight | What it measures |
+| Dimension | Points | What it measures |
 |---|---|---|
-| Reciprocity | 30% | Balance of inbound vs outbound messages |
-| Recency | 25% | How recently you interacted (exponential decay) |
-| Frequency | 20% | How often you interact |
-| Breadth | 15% | Number of platforms you communicate on |
-| Tenure | 10% | How long you've known the contact |
+| Reciprocity | 0-4 | Balance of inbound vs outbound (min/max ratio) |
+| Recency | 0-3 | Stepwise recency buckets (≤7d / ≤30d / ≤90d), halved when there is no inbound message |
+| Frequency | 0-2 | Weighted interaction counts across time windows |
+| Breadth | 0-1 | 1 point if 2+ platforms |
+| Tenure | 0-2 bonus | Long-term contacts (>=20 interactions & >=1yr, or >=50 & >=2yr) |
 
-**Tenure bonus:** 0-2 extra points based on relationship duration (caps at 2 years).
+**Tenure bonus:** 0-2 extra points for long-term contacts. Requires both interaction-count and duration thresholds: >=20 interactions and >=1 year, or >=50 interactions and >=2 years.
 
 **Extended decay:** Interactions from 1-2 years ago still contribute at 0.05x weight; 2-5 years at 0.02x. This prevents long-term contacts from dropping to zero.
 

--- a/docs/docs/features/telegram.md
+++ b/docs/docs/features/telegram.md
@@ -26,8 +26,9 @@ Once authenticated, the session is persisted so you do not need to re-authentica
 | Direct messages | DM dialogs | Daily (03:00 UTC) + manual |
 | Contact info | DM participants | During chat sync |
 | Group members | Private groups / supergroups | First sync only; on-demand thereafter |
-| User bios | Telegram "about" field | Every 3 days (periodic recheck); 7-day freshness filter during chat sync |
+| User bios | Telegram "about" field | Every 3 days (periodic recheck, 3-day staleness); first-sync bio step uses a 7-day staleness filter |
 | Usernames | All synced users | During chat / group sync |
+| Phone/video calls | DM call events | During chat sync (call_type + duration recorded) |
 | Common groups | Shared group memberships | Cached 24 hours |
 
 ## Chat Sync
@@ -108,7 +109,7 @@ Disabling 2nd Tier sync does not delete existing 2nd Tier contacts — use the b
 User bios (the "about" field in Telegram profiles) are periodically checked for changes.
 
 ### Freshness filter
-A 7-day freshness filter skips users whose bios were fetched recently during a chat or group sync, reducing API calls by approximately 70%.
+A freshness filter skips contacts whose bio was last checked within the staleness window (based on each contact's telegram_bio_checked_at timestamp, set only by bio sync). The window is 7 days for the first-sync bio step and 3 days for the periodic recheck.
 
 ### Periodic recheck
 Every 3 days, a background task rechecks bios for all non-2nd-Tier contacts whose `telegram_bio_checked_at` is older than 3 days or null.

--- a/docs/docs/features/twitter.md
+++ b/docs/docs/features/twitter.md
@@ -42,7 +42,7 @@ Tweets that @mention you and your outbound replies are imported as interactions 
 PingCRM periodically checks the Twitter bios of your contacts for changes. When a change is detected:
 
 1. A **notification** is created alerting you to the update.
-2. A **timeline event** is added to the contact's interaction history, recording the old and new bio text.
+2. A **timeline event** is added to the contact's interaction history, recording the new bio text.
 
 Bio changes are a valuable signal for identifying career moves, fundraising activity, and other networking-relevant events.
 
@@ -67,7 +67,7 @@ See [Follow-Up Suggestions](./suggestions.md) for the full suggestion algorithm,
 
 ## Bird CLI (`@steipete/bird`)
 
-PingCRM uses the [Bird CLI](https://www.npmjs.com/package/@anthropic-ai/bird) (`@steipete/bird v0.8.0`) as the **primary** data source for Twitter/X. Bird authenticates via browser cookies rather than API keys, bypassing X API rate limits and credit restrictions.
+PingCRM uses the [Bird CLI](https://www.npmjs.com/package/@steipete/bird) (`@steipete/bird v0.8.0`) as the **primary** data source for Twitter/X. Bird authenticates via browser cookies rather than API keys, bypassing X API rate limits and credit restrictions.
 
 ### What Bird CLI provides
 

--- a/docs/docs/features/whatsapp.md
+++ b/docs/docs/features/whatsapp.md
@@ -36,7 +36,6 @@ Sessions can expire if you remove the linked device from your phone or if WhatsA
 |------|--------|-----------|
 | Direct messages | 1:1 chats | Real-time (via webhook) + 30-day backfill on connect |
 | Contact name | WhatsApp profile | During message sync |
-| About text | WhatsApp "About" field | During message sync |
 
 ### Not synced
 - Group messages
@@ -76,7 +75,7 @@ A daily Celery beat task (`check_whatsapp_sessions`, 01:00 UTC) verifies that al
 
 From Settings > Integrations > WhatsApp, use the kebab menu to disconnect. This:
 
-1. Destroys the sidecar session (including stored auth data).
+1. Destroys the in-memory sidecar session and shuts down its browser. (Stored on-disk auth data under /data/sessions is not deleted.)
 2. Clears the user's WhatsApp connection fields.
 3. Does **not** delete synced interactions or contacts.
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -12,18 +12,20 @@ An AI-powered personal networking CRM that helps you maintain professional relat
 
 ## What is PingCRM?
 
-PingCRM is a single-player networking tool designed for professionals who want to stay on top of their relationships without the overhead of a full-blown CRM. It connects to your existing communication channels (Gmail, Telegram, Twitter/X), analyzes your interaction patterns, and uses AI to suggest who you should reach out to and draft contextual messages.
+PingCRM is a single-player networking tool designed for professionals who want to stay on top of their relationships without the overhead of a full-blown CRM. It connects to your existing communication channels (Gmail, Telegram, Twitter/X, WhatsApp), analyzes your interaction patterns, and uses AI to suggest who you should reach out to and draft contextual messages.
 
 ## Key Capabilities
 
 - **Contact Management** -- import from CSV, Google Contacts, or add manually. Full-text search across names, emails, bios, and message content.
-- **Multi-Platform Sync** -- Gmail threads, Telegram DMs, Twitter DMs and mentions, and LinkedIn messages are automatically imported as interactions.
+- **Multi-Platform Sync** -- Gmail threads, Telegram DMs, Twitter DMs and mentions, LinkedIn messages, and WhatsApp chats (via a QR-paired sidecar) are automatically imported as interactions.
 - **AI Follow-Up Suggestions** -- Claude analyzes your interaction patterns and generates contextual draft messages when it's time to reconnect.
 - **Identity Resolution** -- automatically detects when contacts across different platforms (Gmail, Telegram, Twitter, LinkedIn) are the same person and merges them.
 - **Organization Tracking** -- group contacts by company, track relationship health per org.
 - **LinkedIn Extension** -- Chrome extension syncs LinkedIn messages and profiles via the Voyager API, with AI suggestion buttons injected into the LinkedIn composer.
 - **Bio Monitoring** -- detects Twitter and Telegram bio changes (job changes, milestones) and surfaces them as events.
 - **Relationship Scoring** -- automatic scoring based on interaction recency, frequency, and reciprocity.
+- **Map View** -- a geographic map of your contacts by location, useful for planning trips and local meetups.
+- **MCP Server** -- a read-only Model Context Protocol server that exposes your CRM data to AI clients like Claude Desktop and Cursor.
 
 ## Tech Stack
 

--- a/docs/docs/operations/updates.md
+++ b/docs/docs/operations/updates.md
@@ -38,13 +38,13 @@ By default `docker-compose.prod.yml` uses `:latest`. To pin:
 ```yaml
 services:
   backend:
-    image: ghcr.io/sneg55/pingcrm/backend:v1.7.0
+    image: ghcr.io/sneg55/pingcrm/backend:1.7.0
   frontend:
-    image: ghcr.io/sneg55/pingcrm/frontend:v1.7.0
+    image: ghcr.io/sneg55/pingcrm/frontend:1.7.0
 ```
 
 Available tag forms:
-- `:v1.7.0` — exact version
+- `:1.7.0` — exact version
 - `:1.7` — latest patch in the 1.7 line
 - `:1` — latest minor in the 1.x line
 - `:latest` — most recent release

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -10,7 +10,7 @@ This guide walks you through setting up PingCRM for local development. Docker Co
 ## Prerequisites
 
 - **Docker** and **Docker Compose** (recommended)
-- Or, for manual setup: **Python 3.12+**, **Node.js 18+**, **PostgreSQL 14+**, **Redis 6+**
+- Or, for manual setup: **Python 3.12+**, **Node.js 20+**, **PostgreSQL 14+**, **Redis 6+**
 
 ## 1. Clone the Repository
 
@@ -215,7 +215,7 @@ celery -A worker.celery_app worker --loglevel=info
 | `SECRET_KEY` | Yes | JWT signing key |
 | `DATABASE_URL` | Yes | PostgreSQL connection string (asyncpg) |
 | `REDIS_URL` | No | Redis URL (default: `redis://localhost:6379/0`) |
-| `ENCRYPTION_KEY` | No | Fernet key for stored OAuth tokens |
+| `ENCRYPTION_KEY` | Prod / for OAuth | Fernet key for stored OAuth tokens — required in production and for any platform integration |
 | `GOOGLE_CLIENT_ID` | No | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | No | Google OAuth client secret |
 | `TWITTER_CLIENT_ID` | No | Twitter OAuth 2.0 client ID |


### PR DESCRIPTION
## Summary

Full audit of the Docusaurus documentation site against the current backend, frontend, and Chrome-extension code (driven by the `code → docs` map in `.claude/rules/docs-sync.md`). Every one of the 20 doc pages was checked against its mapped implementation; this PR fixes the drift that had accumulated since the docs were last updated (~2026-05-15) plus behavior added in recent commits.

Each change was verified against a specific `file:line` in the code, and the docs site **builds clean** (`npm run build`).

## Pages with no drift (verified, unchanged)
`api-reference.md`, `features/mcp.md`, `features/settings.md`, `features/organizations.md`

## Corrections by page

**suggestions** — real Pool B1/B2/B3 dormancy windows & thresholds; time-based trigger uses the per-priority interval + relationship-score-below-4 gate; relationship score documented as an additive 0–10 sum of integer point ranges (stepwise recency buckets, not weighted percentages / exponential decay); ghosting guards gated on 30-day recency; LinkedIn added to the no-channel guard; birthday trigger noted as exempt from the interaction cooldown.

**contacts** — actual sort options and score-tier filter (not a range); clarified in-app sending is **Telegram-only** (composer drafts for any channel).

**telegram** — bio freshness explained via `telegram_bio_checked_at` (7-day first sync / 3-day recheck); documented the new structured **call_type + duration_seconds** call logging (a2436c0).

**gmail** — email sync *matches* contacts (does not create them); subject line isn't stored; added the OAuth "In production" requirement note. **twitter** — bio timeline event stores the new bio only; fixed the bird-CLI npm link. **linkedin** — 15-minute throttle (was "2-hour"); P/R buttons paste directly into the composer (the "overlay" never existed).

**notifications** — removed the non-existent identity-match notification; bio-change fires for Telegram too; added auto-tagging; sync-completion is Gmail/Telegram/Twitter only.

**map** — refresh is on Mapbox `moveend` (not debounced); cluster zoom cutoff; 4xx log level.

**identity** — 70–85% manual-review band (below 70% discarded); scan is synchronous (no background job / notification); documented the Organizations tab.

**dashboard / intro / architecture / setup / contributing / operations** — trend-arrow coverage; dashboard send channels; added WhatsApp + MCP + Map to the intro; `check_for_updates` beat task + interaction call fields + corrected envelope import & stale line counts; Node 20; `ENCRYPTION_KEY` prod requirement; accurate pre-push hook description; `:1.7.0` image tag form.

## Verification
- `cd docs && npm run build` → success (caught and fixed an MDX `<`-operator parse issue during review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)