### PR TITLE
fix: make host-based dev DB setup work as documented

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,20 +1,24 @@
 import asyncio
 from logging.config import fileConfig
 
+# app.models is imported for its side effect: registering every model on
+# Base.metadata so Alembic autogenerate can detect them.
+import app.models  # noqa: F401
 from alembic import context
-from sqlalchemy.ext.asyncio import async_engine_from_config
-from sqlalchemy import pool
-
-# Import Base and all models so Alembic can detect them
+from app.core.config import settings
 from app.core.database import Base
-import app.models  # noqa: F401 - ensures all models are registered
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
 
 config = context.config
 
-import os
-db_url = os.environ.get("DATABASE_URL")
-if db_url:
-    config.set_main_option("sqlalchemy.url", db_url)
+# Source the database URL from the application settings so migrations use the
+# exact same configuration as the app. pydantic-settings resolves real
+# environment variables first (e.g. the DATABASE_URL injected by docker compose),
+# then falls back to the .env file, then to the default. This keeps a single
+# source of truth and also applies the +asyncpg driver normalisation defined on
+# Settings.DATABASE_URL.
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,12 @@
 services:
   postgres:
     image: postgres:16-alpine
+    # Published to the host so host-based development (running alembic/uvicorn
+    # from a local venv, per CONTRIBUTING.md) can reach the database at
+    # localhost:5432. Containers on the compose network still use the "postgres"
+    # service hostname.
+    ports:
+      - "5432:5432"
     command:
       - postgres
       - -c
@@ -27,6 +33,9 @@ services:
 
   redis:
     image: redis:7-alpine
+    # Published to the host for host-based development (see postgres above).
+    ports:
+      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
## Problem

Following the host-based development flow in `CONTRIBUTING.md` (run `alembic`/`uvicorn` from a local venv against Dockerized postgres/redis), `alembic upgrade head` fails. There were two stacked issues:

1. **Ports not reachable from the host.** `docker-compose.yml` exposed postgres/redis only on the internal compose network, so a host process connecting to `localhost:5432` got `OSError: [Errno 111] Connect call failed`.
2. **`.env` silently ignored by alembic.** After publishing the port, the next failure was `asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "<os-user>"`. `alembic/env.py` read `DATABASE_URL` from `os.environ` only — it never loaded `.env`. With no env var set, alembic fell back to the credential-less `sqlalchemy.url` in `alembic.ini` and authenticated as the OS user.

## Changes

- **`docker-compose.yml`**: publish `5432` (postgres) and `6379` (redis) to the host. Containers on the compose network are unaffected — they still resolve services by hostname.
- **`backend/alembic/env.py`**: source the DB URL from `app.core.config.settings` instead of raw `os.environ`. This makes migrations use the **same configuration as the application** (single source of truth).

## Why sourcing from `settings` is the robust fix

`Settings` (pydantic-settings) already defines `env_file = ".env"`, so the documented `.env` flow now "just works" by construction. Precedence is preserved:

- real environment variable (the **docker compose** flow, which injects `DATABASE_URL`) →
- `.env` file (the **host venv** flow) →
- default.

It also reuses the existing `+asyncpg` driver normalization on `Settings.DATABASE_URL`, so managed-Postgres URLs (`postgres://…`) keep working.

## Validation

From `backend/` with credentials in `.env`:

```
$ alembic upgrade head
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
$ alembic current
c1b2a3d4e5f6 (head)
```

Both the host flow (`.env`) and the container flow (injected env var) resolve the URL correctly.

## Notes / follow-ups

- `backend/.env.example` still ships a credential-less `DATABASE_URL=postgresql+asyncpg://localhost:5432/pingcrm`. Newcomers must add `pingcrm:<POSTGRES_PASSWORD>@`. Could add a placeholder there in a follow-up to make the requirement obvious.
- Publishing DB/cache ports is appropriate for local dev only; production uses `docker-compose.prod.yml`.