### PR TITLE
fix(linkedin): enrich avatar + company on profile visit, repair ACo contacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,7 @@ alembic revision --autogenerate -m "description"
 
 # API type generation (run after adding/changing API endpoints)
 cd backend && PYTHONPATH=. python3 -c "
-import json; from app.main import app; from fastapi.openapi.utils import get_openapi
+import json; from app.main import fastapi_app as app; from fastapi.openapi.utils import get_openapi
 schema = get_openapi(title=app.title, version=app.version, routes=app.routes)
 with open('openapi.json', 'w') as f: json.dump(schema, f, indent=2)
 "

--- a/backend/app/api/linkedin.py
+++ b/backend/app/api/linkedin.py
@@ -69,6 +69,10 @@ class LinkedInProfilePush(BaseModel):
     profile_id: str
     profile_url: str
     full_name: str
+    # Stable member id (ACo…) from the profile URN. Lets us match a contact
+    # created from a DM (keyed on this id) to a profile fetched by public slug,
+    # and repair its anonymized identity.
+    member_id: str | None = None
     headline: str | None = None
     company: str | None = None
     location: str | None = None
@@ -90,6 +94,10 @@ class LinkedInMessagePush(BaseModel):
 class LinkedInPushRequest(BaseModel):
     profiles: list[LinkedInProfilePush] = Field(default=[], max_length=50)
     messages: list[LinkedInMessagePush] = Field(default=[], max_length=500)
+    # When true, profiles that don't match an existing contact are skipped
+    # rather than created. Used by profile-visit enrichment so opening a
+    # stranger's profile doesn't spam the CRM with new contacts.
+    enrich_only: bool = False
 
 
 @router.post("/push", response_model=Envelope[LinkedInPushResult])
@@ -157,8 +165,20 @@ async def push_linkedin_data(
         contact = profile_id_map.get(profile.profile_id)
         if not contact and profile_url_normalized:
             contact = url_map.get(profile_url_normalized)
+        # Match contacts created from DMs, which are keyed on the anonymized
+        # member id (ACo…) rather than the public slug.
+        if not contact and profile.member_id:
+            contact = profile_id_map.get(profile.member_id)
 
         if contact:
+            # Repair anonymized identity: upgrade an ACo member-id contact to
+            # the real public slug now that we know it.
+            if profile.profile_id and (
+                not contact.linkedin_profile_id
+                or contact.linkedin_profile_id.startswith("ACo")
+            ):
+                contact.linkedin_profile_id = profile.profile_id
+                profile_id_map[profile.profile_id] = contact
             # Update fields — respect user-edited field protection
             sync_set_field(contact, "full_name", profile.full_name)
             if profile.headline:
@@ -186,6 +206,10 @@ async def push_linkedin_data(
                     contact.avatar_url = local_path
             contacts_updated += 1
         else:
+            # Enrichment-only push (e.g. profile visit): don't create a contact
+            # for someone who isn't already in the CRM.
+            if body.enrich_only:
+                continue
             name_parts = (profile.full_name or "").split(None, 1)
             contact, created = await find_or_create_contact_by_linkedin_profile_id(
                 db, current_user.id, profile.profile_id,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3489,7 +3489,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Get Sync Progress Api V1 Telegram Sync Progress Get"
                 }
@@ -5772,7 +5771,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Report Frontend Error Api V1 Errors Post"
                 }
@@ -5805,7 +5803,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "type": "object",
                   "title": "Response Health Check Api Health Get"
                 }
@@ -7592,7 +7589,6 @@
         "properties": {
           "created": {
             "items": {
-              "additionalProperties": true,
               "type": "object"
             },
             "type": "array",
@@ -7801,7 +7797,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -7840,7 +7835,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -7879,7 +7873,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -7918,7 +7911,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -7957,7 +7949,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -7996,7 +7987,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8035,7 +8025,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8074,7 +8063,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8113,7 +8101,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8152,7 +8139,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8191,7 +8177,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8230,7 +8215,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8269,7 +8253,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8308,7 +8291,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8347,7 +8329,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8386,7 +8367,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8425,7 +8405,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8464,7 +8443,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8503,7 +8481,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8542,7 +8519,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8581,7 +8557,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8620,7 +8595,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8659,7 +8633,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8698,7 +8671,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8737,7 +8709,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8776,7 +8747,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8815,7 +8785,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8854,7 +8823,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8893,7 +8861,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8932,7 +8899,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -8971,7 +8937,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9010,7 +8975,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9049,7 +9013,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9088,7 +9051,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9127,7 +9089,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9166,7 +9127,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9205,7 +9165,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9244,7 +9203,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9283,7 +9241,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9322,7 +9279,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9361,7 +9317,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9400,7 +9355,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9439,7 +9393,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9478,7 +9431,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9517,7 +9469,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9556,7 +9507,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9595,7 +9545,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9634,7 +9583,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9673,7 +9621,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9712,7 +9659,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9751,7 +9697,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9790,7 +9735,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9829,7 +9773,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9868,7 +9811,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9907,7 +9849,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9925,7 +9866,6 @@
           "data": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9948,7 +9888,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -9989,7 +9928,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10032,7 +9970,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10075,7 +10012,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10118,7 +10054,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10161,7 +10096,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10204,7 +10138,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10247,7 +10180,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10290,7 +10222,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10333,7 +10264,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10352,7 +10282,6 @@
             "anyOf": [
               {
                 "items": {
-                  "additionalProperties": true,
                   "type": "object"
                 },
                 "type": "array"
@@ -10377,7 +10306,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -10420,7 +10348,6 @@
           "meta": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -11062,6 +10989,17 @@
             "type": "string",
             "title": "Full Name"
           },
+          "member_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Member Id"
+          },
           "headline": {
             "anyOf": [
               {
@@ -11156,6 +11094,11 @@
             "maxItems": 500,
             "title": "Messages",
             "default": []
+          },
+          "enrich_only": {
+            "type": "boolean",
+            "title": "Enrich Only",
+            "default": false
           }
         },
         "type": "object",
@@ -12803,22 +12746,18 @@
       "SyncSettingsData": {
         "properties": {
           "telegram": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Telegram"
           },
           "gmail": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Gmail"
           },
           "twitter": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Twitter"
           },
           "linkedin": {
-            "additionalProperties": true,
             "type": "object",
             "title": "Linkedin"
           }
@@ -12837,7 +12776,6 @@
           "telegram": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -12849,7 +12787,6 @@
           "gmail": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -12861,7 +12798,6 @@
           "twitter": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -12873,7 +12809,6 @@
           "linkedin": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -13384,7 +13319,6 @@
           "priority_settings": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {

--- a/backend/tests/test_linkedin_api.py
+++ b/backend/tests/test_linkedin_api.py
@@ -594,3 +594,125 @@ async def test_push_matches_contact_by_name_when_profile_id_is_urn(
     # Existing contact should now have the URN stored as linkedin_profile_id
     await db.refresh(existing)
     assert existing.linkedin_profile_id == urn_id
+
+
+# ---------------------------------------------------------------------------
+# Profile-visit enrichment: member_id matching, ACo repair, enrich_only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_profile_push_repairs_aco_contact_via_member_id(
+    client: AsyncClient,
+    auth_headers: dict,
+    db: AsyncSession,
+    test_user,
+):
+    """A profile-visit push (slug + member_id) should match a contact created
+    from a DM under the anonymized ACo member id, enrich it, and upgrade its
+    identity to the real public slug."""
+    aco_id = "ACoAAAFS80wBexample"
+    existing = Contact(
+        user_id=test_user.id,
+        full_name="Matt Lam",
+        linkedin_profile_id=aco_id,  # created from a DM — anonymized id
+        linkedin_url=f"https://www.linkedin.com/in/{aco_id}",
+        source="linkedin",
+    )
+    db.add(existing)
+    await db.commit()
+    await db.refresh(existing)
+
+    payload = {
+        "enrich_only": True,
+        "profiles": [
+            {
+                "profile_id": "mattjlam",
+                "member_id": aco_id,
+                "profile_url": "https://www.linkedin.com/in/mattjlam",
+                "full_name": "Matt Lam",
+                "headline": "Builder of Web3 Services",
+                "company": "Bloq",
+                "location": "San Francisco Bay Area",
+            }
+        ],
+        "messages": [],
+    }
+
+    resp = await client.post(PUSH_URL, json=payload, headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["contacts_created"] == 0
+    assert data["contacts_updated"] == 1
+
+    await db.refresh(existing)
+    assert existing.company == "Bloq"
+    assert existing.linkedin_headline == "Builder of Web3 Services"
+    # ACo identity repaired to the real slug
+    assert existing.linkedin_profile_id == "mattjlam"
+
+
+@pytest.mark.asyncio
+async def test_enrich_only_does_not_create_unknown_contact(
+    client: AsyncClient,
+    auth_headers: dict,
+    db: AsyncSession,
+    test_user,
+):
+    """enrich_only push for a profile that matches no contact must NOT create one."""
+    payload = {
+        "enrich_only": True,
+        "profiles": [
+            {
+                "profile_id": "stranger-xyz",
+                "member_id": "ACoStrangerXyz",
+                "profile_url": "https://www.linkedin.com/in/stranger-xyz",
+                "full_name": "Random Stranger",
+                "company": "NowhereCo",
+            }
+        ],
+        "messages": [],
+    }
+
+    resp = await client.post(PUSH_URL, json=payload, headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["contacts_created"] == 0
+    assert data["contacts_updated"] == 0
+
+    result = await db.execute(
+        select(Contact).where(Contact.linkedin_profile_id == "stranger-xyz")
+    )
+    assert result.scalar_one_or_none() is None, "enrich_only must not create strangers"
+
+
+@pytest.mark.asyncio
+async def test_non_enrich_push_still_creates_contact(
+    client: AsyncClient,
+    auth_headers: dict,
+    db: AsyncSession,
+    test_user,
+):
+    """Default (non-enrich) profile push still creates contacts (backfill path)."""
+    payload = {
+        "profiles": [
+            {
+                "profile_id": "created-via-backfill",
+                "profile_url": "https://www.linkedin.com/in/created-via-backfill",
+                "full_name": "New Person",
+                "company": "AcmeCorp",
+            }
+        ],
+        "messages": [],
+    }
+
+    resp = await client.post(PUSH_URL, json=payload, headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["contacts_created"] == 1
+
+    result = await db.execute(
+        select(Contact).where(Contact.linkedin_profile_id == "created-via-backfill")
+    )
+    c = result.scalar_one_or_none()
+    assert c is not None
+    assert c.company == "AcmeCorp"

--- a/chrome-extension/background/service-worker.js
+++ b/chrome-extension/background/service-worker.js
@@ -50,6 +50,11 @@ function setBadge(text, color) {
 let _lastProfileSyncAt = 0;
 const PROFILE_SYNC_THROTTLE_MS = 5 * 60 * 1000; // 5 minutes
 
+// Per-slug throttle for profile-visit capture (avoid re-fetching the same
+// person every time the user reopens their profile).
+const _profileVisitAt = {};
+const PROFILE_VISIT_THROTTLE_MS = 10 * 60 * 1000; // 10 minutes per profile
+
 // ── Throttle state for Meta auto-sync ────────────────────────────────────────
 let _lastMetaSyncAt = 0;
 const META_AUTO_SYNC_THROTTLE_MS = 5 * 60 * 1000; // 5 minutes
@@ -127,6 +132,95 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         console.warn("[PingCRM SW] Cookie refresh failed:", e.message);
       }
       sendResponse({ ok: true });
+    })();
+    return true;
+  }
+
+  // PROFILE_VISIT — user opened a member profile page (/in/<slug>). Fetch that
+  // person via Voyager and enrich the matching contact (avatar, company,
+  // headline). Unlike DM sync, this is the only path that has the public slug,
+  // so it can also repair contacts stored under an anonymized ACo member id.
+  if (message.type === "PROFILE_VISIT") {
+    (async () => {
+      try {
+        const slug = (message.slug || "").trim();
+        // ACo member ids aren't accepted by the profile endpoint (needs a slug).
+        if (!slug || /^aco/i.test(slug)) {
+          sendResponse({ ok: false, error: "NO_SLUG" });
+          return;
+        }
+
+        const { apiUrl, token } = await chrome.storage.local.get(["apiUrl", "token"]);
+        if (!apiUrl || !token) {
+          sendResponse({ ok: false, error: "Not paired" });
+          return;
+        }
+
+        const now = Date.now();
+        if (now - (_profileVisitAt[slug] || 0) < PROFILE_VISIT_THROTTLE_MS) {
+          sendResponse({ ok: true, throttled: true });
+          return;
+        }
+        _profileVisitAt[slug] = now;
+
+        const cookies = await chrome.cookies.getAll({ domain: ".linkedin.com" });
+        const liAt = cookies.find(c => c.name === "li_at")?.value;
+        const jsid = cookies.find(c => c.name === "JSESSIONID")?.value;
+        if (!liAt || !jsid) {
+          sendResponse({ ok: false, error: "MISSING_COOKIES" });
+          return;
+        }
+
+        const raw = await voyagerGetProfile(liAt, jsid, slug);
+        const fields = _extractProfileFields(raw);
+        if (!fields) {
+          console.warn("[ProfileVisit] No profile object for:", slug);
+          sendResponse({ ok: false, error: "NO_PROFILE" });
+          return;
+        }
+
+        let avatarData = null;
+        if (fields.avatarUrl) {
+          try {
+            avatarData = await fetchLinkedInImageAsBase64(fields.avatarUrl);
+          } catch (err) {
+            console.warn("[ProfileVisit] Avatar fetch failed for:", slug, err.message);
+          }
+        }
+
+        const resp = await fetch(`${apiUrl}/api/v1/linkedin/push`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "Authorization": `Bearer ${token}` },
+          body: JSON.stringify({
+            // Enrich existing contacts only — don't create a CRM entry for every
+            // stranger whose profile you happen to open.
+            enrich_only: true,
+            profiles: [{
+              profile_id: slug,
+              member_id: fields.memberId,
+              profile_url: `https://www.linkedin.com/in/${slug}`,
+              full_name: fields.fullName,
+              headline: fields.headline,
+              company: fields.company,
+              location: fields.location,
+              avatar_url: fields.avatarUrl,
+              avatar_data: avatarData,
+            }],
+            messages: [],
+          }),
+        });
+
+        if (!resp.ok) {
+          console.warn("[ProfileVisit] Push failed:", slug, resp.status);
+          sendResponse({ ok: false, error: `PUSH_FAILED:${resp.status}` });
+          return;
+        }
+        console.log("[ProfileVisit] Enriched:", slug, "company:", fields.company, "avatar:", !!avatarData);
+        sendResponse({ ok: true, company: fields.company, avatar: !!avatarData });
+      } catch (e) {
+        console.warn("[ProfileVisit] Failed:", message.slug, e.message);
+        sendResponse({ ok: false, error: e.message });
+      }
     })();
     return true;
   }
@@ -496,31 +590,18 @@ async function _runPendingBackfill() {
       const raw = await voyagerGetProfile(liAt, jsid, publicId);
       console.log("[Backfill] Got response for:", publicId);
 
-      const profileObj = (raw?.included ?? []).find(
-        i => i?.$type?.includes("Profile") || i?.$type?.includes("MiniProfile")
-      );
-      if (!profileObj) {
+      const fields = _extractProfileFields(raw);
+      if (!fields) {
         console.log("[Backfill] No profile object in response for:", publicId);
         continue;
-      }
-
-      // Extract avatar URL
-      let avatarUrl = null;
-      const artifacts = profileObj?.profilePicture?.displayImageReference?.vectorImage?.artifacts ?? [];
-      if (artifacts.length > 0) {
-        const largest = artifacts[artifacts.length - 1];
-        const rootUrl = profileObj?.profilePicture?.displayImageReference?.vectorImage?.rootUrl ?? "";
-        if (rootUrl && largest?.fileIdentifyingUrlPathSegment) {
-          avatarUrl = rootUrl + largest.fileIdentifyingUrlPathSegment;
-        }
       }
 
       // Fetch the image bytes inside the LinkedIn tab — the backend can't
       // download from media.licdn.com directly (CDN returns 403 server-side).
       let avatarData = null;
-      if (avatarUrl) {
+      if (fields.avatarUrl) {
         try {
-          avatarData = await fetchLinkedInImageAsBase64(avatarUrl);
+          avatarData = await fetchLinkedInImageAsBase64(fields.avatarUrl);
         } catch (err) {
           console.warn("[Backfill] Avatar fetch failed for:", publicId, err.message);
         }
@@ -536,17 +617,19 @@ async function _runPendingBackfill() {
         body: JSON.stringify({
           profiles: [{
             profile_id: publicId,
+            member_id: fields.memberId,
             profile_url: `https://www.linkedin.com/in/${publicId}`,
-            full_name: [profileObj?.firstName, profileObj?.lastName].filter(Boolean).join(" ") || null,
-            headline: profileObj?.headline ?? null,
-            location: profileObj?.geoLocationName ?? null,
-            avatar_url: avatarUrl,
+            full_name: fields.fullName,
+            headline: fields.headline,
+            company: fields.company,
+            location: fields.location,
+            avatar_url: fields.avatarUrl,
             avatar_data: avatarData,
           }],
           messages: [],
         }),
       });
-      console.log("[Backfill] Pushed profile for:", publicId, "avatar:", !!avatarUrl, "bytes:", !!avatarData);
+      console.log("[Backfill] Pushed profile for:", publicId, "company:", fields.company, "avatar:", !!fields.avatarUrl, "bytes:", !!avatarData);
       processed++;
     } catch (e) {
       // Only stop on rate limiting — individual profile 401/403/404 are expected for bad IDs

--- a/chrome-extension/background/sync-utils.js
+++ b/chrome-extension/background/sync-utils.js
@@ -184,6 +184,63 @@ function _eventToMessage(msg, conversationUrn, partnerPublicId, partnerName, sel
   };
 }
 
+// ── Profile extraction ───────────────────────────────────────────────────────
+
+/**
+ * Extract contact fields from a Voyager /identity/dash/profiles response.
+ *
+ * Shared by profile-visit capture and backfill so the two paths can never
+ * drift. Pulls:
+ *   - memberId: the stable member id (ACo…) from the profile entityUrn. This
+ *     is what contacts created from DMs are keyed on, so it lets the backend
+ *     match a slug-fetched profile back to an anonymized contact.
+ *   - fullName / headline / location
+ *   - company / title from the CURRENT position (a Position with no
+ *     dateRange.end). Among several current roles, the latest start wins.
+ *   - avatarUrl: largest artifact under the display image vector.
+ *
+ * @returns {null | {memberId,fullName,headline,location,company,title,avatarUrl}}
+ */
+function _extractProfileFields(raw) {
+  const included = raw?.included ?? [];
+  const profileObj = included.find(
+    i => /\.Profile$/.test(i?.$type || "") || (i?.$type || "").includes("MiniProfile")
+  );
+  if (!profileObj) return null;
+
+  const memberId = (profileObj.entityUrn || "").split(":").pop() || null;
+
+  let avatarUrl = null;
+  const artifacts = profileObj?.profilePicture?.displayImageReference?.vectorImage?.artifacts ?? [];
+  if (artifacts.length > 0) {
+    const largest = artifacts[artifacts.length - 1];
+    const rootUrl = profileObj?.profilePicture?.displayImageReference?.vectorImage?.rootUrl ?? "";
+    if (rootUrl && largest?.fileIdentifyingUrlPathSegment) {
+      avatarUrl = rootUrl + largest.fileIdentifyingUrlPathSegment;
+    }
+  }
+
+  const positions = included.filter(i => /\.Position$/.test(i?.$type || ""));
+  const startScore = (p) => {
+    const s = p?.dateRange?.start;
+    return s ? (s.year || 0) * 12 + (s.month || 0) : 0;
+  };
+  const current = positions.filter(p => !p?.dateRange?.end);
+  const pick = (current.length ? current : positions)
+    .slice()
+    .sort((a, b) => startScore(b) - startScore(a))[0] ?? null;
+
+  return {
+    memberId,
+    fullName: [profileObj.firstName, profileObj.lastName].filter(Boolean).join(" ") || null,
+    headline: profileObj.headline ?? null,
+    location: profileObj.geoLocationName ?? null,
+    company: pick?.companyName ?? null,
+    title: pick?.title ?? null,
+    avatarUrl,
+  };
+}
+
 // ── Error handler ────────────────────────────────────────────────────────────
 
 /**

--- a/chrome-extension/content/linkedin-notify.js
+++ b/chrome-extension/content/linkedin-notify.js
@@ -14,6 +14,37 @@ try {
   // Extension context may not be ready yet
 }
 
+// ── Profile capture ──────────────────────────────────────────────────────────
+// On a member profile page (/in/<slug>), ask the service worker to fetch and
+// enrich that contact via Voyager. LinkedIn is an SPA — navigating between
+// profiles doesn't reload this content script — so poll the URL and fire once
+// per distinct slug. The SW additionally throttles per slug.
+const _capturedSlugs = new Set();
+
+function _currentProfileSlug() {
+  const m = window.location.pathname.match(/^\/in\/([^/?#]+)/);
+  if (!m) return null;
+  const slug = decodeURIComponent(m[1]);
+  // Anonymized member URNs (ACo…) aren't accepted by the profile endpoint.
+  if (/^aco/i.test(slug)) return null;
+  return slug;
+}
+
+function _maybeCaptureProfile() {
+  const slug = _currentProfileSlug();
+  if (!slug || _capturedSlugs.has(slug)) return;
+  _capturedSlugs.add(slug);
+  try {
+    chrome.runtime.sendMessage({ type: "PROFILE_VISIT", slug });
+  } catch (e) {
+    // Extension context not ready — allow a later retry for this slug.
+    _capturedSlugs.delete(slug);
+  }
+}
+
+_maybeCaptureProfile();
+setInterval(_maybeCaptureProfile, 3000);
+
 // ── Voyager proxy ────────────────────────────────────────────────────────────
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message.type !== "VOYAGER_PROXY") return false;

--- a/chrome-extension/test/.gitignore
+++ b/chrome-extension/test/.gitignore
@@ -1,0 +1,2 @@
+# Scratch/throwaway probe files
+_validate-tmp.mjs

--- a/chrome-extension/test/README.md
+++ b/chrome-extension/test/README.md
@@ -1,0 +1,76 @@
+# Debugging the PingCRM companion extension without a manual browser
+
+Three layers, each removing more manual work. Layers 1–2 are fully offline
+(no browser, no LinkedIn login, no cookies) and run in <1s. Layer 3 exercises
+real Voyager but is fully scripted — no clicking.
+
+```
+test/
+├── helpers/
+│   ├── chrome-stub.mjs     in-memory chrome.* (storage, cookies, tabs, scripting, action)
+│   ├── loader.mjs          loads the REAL sw modules into a Node vm context (importScripts emulation)
+│   ├── fake-backend.mjs    fetch() replacement recording /linkedin/push etc.
+│   └── voyager-router.mjs  maps executeScript Voyager calls → fixtures (the one browser seam)
+├── fixtures/voyager/*.json synthetic Voyager responses the parsers accept
+├── layer1.logic.test.mjs   drives runSync() directly
+├── layer2.router.test.mjs  loads service-worker.js, drives it via SYNC_NOW / START_PAIRING / DISCONNECT
+└── capture-and-e2e.mjs     Layer 3: CDP-driven real-Voyager capture + smoke
+```
+
+## Why this works
+
+The entire sync path is plain JS that loads via `importScripts` and shares one
+global scope. The **only** browser-coupled seam is one call in
+`voyager-client.js`:
+
+```
+voyagerFetch() → chrome.scripting.executeScript({target:{tabId}, func})
+```
+
+`loader.mjs` reproduces the `importScripts` global-scope model by concatenating
+the real module sources and running them once in a `node:vm` context whose
+globals are our stubs (`chrome`, `fetch`, a frozen `Date`, `crypto`). Nothing in
+the extension is modified or duplicated — the tests run the shipping code.
+
+## Layer 1 & 2 — offline (default)
+
+```bash
+cd chrome-extension/test
+node --test "**/*.test.mjs"      # or: npm test
+```
+
+Covers: first-sync vs delta (watermark) filtering, message direction from self
+URN, `/linkedin/push` payload shape, missing-cookie / no-tab error surfacing,
+401→silent-refresh, pairing-code format, and the full popup→SW message router.
+
+Determinism: `Date.now()` is frozen to `FIXED_NOW = 1750000000000`, and the
+1s Voyager rate-limit delays resolve instantly (`loader.mjs` stubs `setTimeout`).
+
+### Testing against a real local backend (optional)
+Skip `fake-backend.mjs` and pass Node's global `fetch` with a real `API_URL` and
+a paired extension token instead of `tok`. Useful to verify the backend dedup /
+auto-merge path end-to-end while still mocking Voyager.
+
+## Layer 3 — scripted real Voyager (needs your li_at once)
+
+Talks to Chrome over the DevTools Protocol (built-in `WebSocket`, no Playwright/
+puppeteer) because an MV3 service worker can't be reached by page-automation
+tools. Loads the unpacked extension, injects `li_at`, opens a LinkedIn tab, then
+attaches to the SW target and calls its own `runSync` / Voyager globals — no
+popup clicking.
+
+```bash
+# Capture fresh fixtures from a live session (→ fixtures/voyager/_captured/, gitignored)
+LINKEDIN_LI_AT=AQ... node capture-and-e2e.mjs --capture
+
+# Real end-to-end smoke against a local backend (needs a paired token)
+LINKEDIN_LI_AT=AQ... API_URL=http://localhost:8000 EXT_TOKEN=... \
+  node capture-and-e2e.mjs --e2e
+```
+
+Env: `LINKEDIN_LI_AT` (required), `CHROME_BIN` (default macOS Chrome),
+`CDP_PORT` (default 9222), `API_URL`/`EXT_TOKEN` (--e2e only).
+
+**Refreshing offline fixtures:** run `--capture`, review/sanitize the JSON in
+`fixtures/voyager/_captured/`, then copy into `fixtures/voyager/`. That keeps
+Layers 1–2 aligned with LinkedIn's current Voyager schema.

--- a/chrome-extension/test/capture-and-e2e.mjs
+++ b/chrome-extension/test/capture-and-e2e.mjs
@@ -1,0 +1,298 @@
+/**
+ * Layer 3 — scripted real-Voyager capture + E2E smoke (NO manual clicking).
+ *
+ * Launches a headed Chrome with the unpacked extension loaded, injects the
+ * user's li_at cookie, opens a LinkedIn tab, then attaches to the extension's
+ * *service-worker* target over the Chrome DevTools Protocol and calls the SW's
+ * own globals directly. This is the only layer that exercises real cookies /
+ * CSRF / Voyager, so it's the one that catches "LinkedIn changed their schema".
+ *
+ * It talks raw CDP over Node's built-in WebSocket (no Playwright/puppeteer,
+ * zero dependencies) because page-automation tools cannot reach an MV3 service
+ * worker — only CDP can.
+ *
+ *   Capture fresh fixtures (writes test/fixtures/voyager/_captured/, gitignored):
+ *     LINKEDIN_LI_AT=AQ... node test/capture-and-e2e.mjs --capture
+ *
+ *   Real end-to-end smoke against a local backend (requires a paired token):
+ *     LINKEDIN_LI_AT=AQ... API_URL=http://localhost:8000 EXT_TOKEN=... \
+ *       node test/capture-and-e2e.mjs --e2e
+ *
+ * Env:
+ *   LINKEDIN_LI_AT  (required) the li_at cookie value from a logged-in session
+ *   CHROME_BIN      (optional) path to Chrome; defaults to macOS Google Chrome
+ *   CDP_PORT        (optional) remote-debugging port (default 9222)
+ *   API_URL,EXT_TOKEN  (--e2e only) backend base URL + extension bearer token
+ */
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const EXT_DIR = path.resolve(HERE, "..");
+// --profile=<slug> probes one profile through the backfill extraction logic.
+const PROFILE_ARG = process.argv.find((a) => a.startsWith("--profile"));
+const PROFILE_SLUG = PROFILE_ARG ? (PROFILE_ARG.split("=")[1] || process.argv[process.argv.indexOf(PROFILE_ARG) + 1]) : null;
+const MODE = PROFILE_ARG ? "profile" : process.argv.includes("--capture") ? "capture" : "e2e";
+const PORT = Number(process.env.CDP_PORT || 9222);
+const CHROME_BIN =
+  process.env.CHROME_BIN || "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const LI_AT = process.env.LINKEDIN_LI_AT;
+
+if (!LI_AT) {
+  console.error("✖ LINKEDIN_LI_AT env var is required (li_at cookie from a logged-in LinkedIn session).");
+  process.exit(2);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── Minimal CDP client over the built-in WebSocket ───────────────────────────
+function cdp(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  let nextId = 1;
+  const pending = new Map();
+  const handlers = [];
+  const ready = new Promise((res, rej) => {
+    ws.addEventListener("open", () => res());
+    ws.addEventListener("error", (e) => rej(e));
+  });
+  ws.addEventListener("message", (ev) => {
+    const msg = JSON.parse(ev.data);
+    if (msg.id && pending.has(msg.id)) {
+      const { resolve, reject } = pending.get(msg.id);
+      pending.delete(msg.id);
+      msg.error ? reject(new Error(msg.error.message)) : resolve(msg.result);
+    } else if (msg.method) {
+      for (const h of handlers) h(msg);
+    }
+  });
+  const send = (method, params = {}, sessionId) =>
+    new Promise((resolve, reject) => {
+      const id = nextId++;
+      pending.set(id, { resolve, reject });
+      ws.send(JSON.stringify({ id, method, params, ...(sessionId ? { sessionId } : {}) }));
+    });
+  return { ready, send, on: (h) => handlers.push(h), close: () => ws.close() };
+}
+
+const httpJson = async (url) => (await fetch(url)).json();
+
+// ── Launch Chrome with the unpacked extension ────────────────────────────────
+async function launchChrome() {
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pingcrm-ext-"));
+  const args = [
+    `--remote-debugging-port=${PORT}`,
+    `--user-data-dir=${userDataDir}`,
+    `--load-extension=${EXT_DIR}`,
+    `--disable-extensions-except=${EXT_DIR}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    // Recent Chrome (137+) disables the --load-extension switch via this
+    // feature; turn it back off so the unpacked extension actually loads.
+    "--disable-features=DialMediaRouteProvider,DisableLoadExtensionCommandLineSwitch",
+    "about:blank",
+  ];
+  const proc = spawn(CHROME_BIN, args, { stdio: "ignore" });
+  proc.on("error", (e) => {
+    console.error(`✖ Failed to launch Chrome at ${CHROME_BIN}: ${e.message}`);
+    console.error("  Set CHROME_BIN to your Chrome path.");
+    process.exit(2);
+  });
+  // Wait for the debugging endpoint and grab the browser-level ws.
+  for (let i = 0; i < 50; i++) {
+    try {
+      const ver = await httpJson(`http://localhost:${PORT}/json/version`);
+      return { proc, userDataDir, browserWs: ver.webSocketDebuggerUrl };
+    } catch {
+      await sleep(200);
+    }
+  }
+  throw new Error("Chrome devtools endpoint never came up");
+}
+
+// Connect to the browser endpoint and turn on target discovery. Extension
+// service workers are NOT listed by /json/list — they only surface via the
+// Target domain, so everything below multiplexes over this one connection
+// (flatten mode: each attached target gets a sessionId).
+async function connectBrowser(browserWs) {
+  const b = cdp(browserWs);
+  await b.ready;
+  const targets = new Map();
+  b.on((msg) => {
+    if (msg.method === "Target.targetCreated" || msg.method === "Target.targetInfoChanged") {
+      targets.set(msg.params.targetInfo.targetId, msg.params.targetInfo);
+    } else if (msg.method === "Target.targetDestroyed") {
+      targets.delete(msg.params.targetId);
+    }
+  });
+  // Explicit empty filter clause {} = "match everything", incl. service_worker,
+  // which the default discovery filter omits.
+  await b.send("Target.setDiscoverTargets", { discover: true, filter: [{}] });
+  // Seed from a snapshot too, in case targetCreated fired before we subscribed.
+  const seed = await b.send("Target.getTargets", { filter: [{}] });
+  for (const t of seed.targetInfos ?? []) targets.set(t.targetId, t);
+  return { b, targets };
+}
+
+async function waitForTargetInfo(targets, pred, label, timeoutMs = 25000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const t of targets.values()) if (pred(t)) return t;
+    await sleep(300);
+  }
+  const seen = [...targets.values()].map((t) => `${t.type} ${t.url}`).join("\n   ");
+  throw new Error(`Timed out waiting for target: ${label}\n   discovered targets:\n   ${seen || "(none)"}`);
+}
+
+// Attach to a target in flatten mode → session-scoped send().
+async function attach(b, targetId) {
+  const { sessionId } = await b.send("Target.attachToTarget", { targetId, flatten: true });
+  return { sessionId, send: (method, params) => b.send(method, params, sessionId) };
+}
+
+// Create a tab, inject li_at, navigate to LinkedIn so cookies+CSRF exist.
+async function openLinkedInTab(b) {
+  const { targetId } = await b.send("Target.createTarget", { url: "about:blank" });
+  const s = await attach(b, targetId);
+  await s.send("Network.enable", {});
+  await s.send("Network.setCookie", {
+    name: "li_at",
+    value: LI_AT,
+    domain: ".linkedin.com",
+    path: "/",
+    secure: true,
+    httpOnly: true,
+  });
+  await s.send("Page.enable", {});
+  await s.send("Page.navigate", { url: "https://www.linkedin.com/feed/" });
+  await sleep(6000); // let the SPA settle so JSESSIONID lands on document.cookie
+  return s;
+}
+
+// Attach to the extension service worker → eval() helper + console streaming.
+async function attachServiceWorker(b, targets) {
+  const sw = await waitForTargetInfo(
+    targets,
+    (t) => t.type === "service_worker" && /service-worker\.js/.test(t.url),
+    "extension service worker",
+  );
+  const s = await attach(b, sw.targetId);
+  await s.send("Runtime.enable", {});
+  b.on((msg) => {
+    if (msg.sessionId === s.sessionId && msg.method === "Runtime.consoleAPICalled") {
+      const text = msg.params.args.map((a) => a.value ?? a.description ?? "").join(" ");
+      console.log("   [SW]", text);
+    }
+  });
+  const evaluate = async (expression) => {
+    const r = await s.send("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    if (r.exceptionDetails) {
+      throw new Error("SW eval failed: " + (r.exceptionDetails.exception?.description || r.exceptionDetails.text));
+    }
+    return r.result.value;
+  };
+  return { evaluate };
+}
+
+// ── Modes ────────────────────────────────────────────────────────────────────
+async function runCapture(evaluate) {
+  console.log("→ Capturing raw Voyager responses via the SW's own client...");
+  const raw = await evaluate(`(async () => {
+    const { liAt, jsessionid } = await _readLinkedInCookies();
+    const selfUrn = await voyagerGetSelfUrn(liAt, jsessionid);
+    const conversations = await voyagerGetConversations(liAt, jsessionid, selfUrn);
+    const firstConv = (conversations?.data?.messengerConversationsBySyncToken?.elements
+      ?? conversations?.data?.messengerConversations?.elements ?? [])[0];
+    const convUrn = firstConv?.backendUrn ?? firstConv?.entityUrn ?? null;
+    const messages = convUrn ? await voyagerGetConversationMessages(liAt, jsessionid, convUrn) : null;
+    return { selfUrn, me: { selfUrn }, conversations, messages };
+  })()`);
+
+  const outDir = path.join(EXT_DIR, "test/fixtures/voyager/_captured");
+  fs.mkdirSync(outDir, { recursive: true });
+  const write = (name, obj) => fs.writeFileSync(path.join(outDir, name), JSON.stringify(obj, null, 2));
+  write("self-urn.json", { selfUrn: raw.selfUrn });
+  write("conversations.page1.json", raw.conversations);
+  if (raw.messages) write("messages.conv1.json", raw.messages);
+  console.log(`✓ Wrote raw fixtures to ${outDir} (gitignored — contains real data).`);
+  console.log("  Review + sanitize, then copy into test/fixtures/voyager/ to update the offline suite.");
+}
+
+async function runE2E(evaluate) {
+  const apiUrl = process.env.API_URL;
+  const token = process.env.EXT_TOKEN;
+  if (!apiUrl || !token) {
+    console.error("✖ --e2e requires API_URL and EXT_TOKEN (a paired extension bearer token).");
+    process.exit(2);
+  }
+  console.log(`→ Running real sync against ${apiUrl} ...`);
+  const result = await evaluate(`(async () => {
+    await chrome.storage.local.set({ apiUrl: ${JSON.stringify(apiUrl)}, token: ${JSON.stringify(token)} });
+    return await runSync(${JSON.stringify(apiUrl)}, ${JSON.stringify(token)}, true);
+  })()`);
+  console.log("→ runSync result:", JSON.stringify(result));
+  if (result.error) {
+    console.error(`✖ Sync reported error: ${result.error}`);
+    process.exitCode = 1;
+  } else if (result.messages === 0) {
+    console.warn("⚠ Sync ran but pushed 0 messages — check watermark / account has recent DMs.");
+  } else {
+    console.log(`✓ E2E smoke passed: ${result.conversations} conversations, ${result.messages} messages.`);
+  }
+}
+
+// Diagnostic: fetch one profile and run it through the SAME extraction the
+// backfill uses, so we can see exactly what avatar/company/headline come out.
+async function runProfileProbe(evaluate, slug) {
+  console.log(`→ Probing profile "${slug}" through the backfill extraction...`);
+  const out = await evaluate(`(async () => {
+    const { liAt, jsessionid } = await _readLinkedInCookies();
+    const raw = await voyagerGetProfile(liAt, jsessionid, ${JSON.stringify(slug)});
+    const included = raw?.included ?? [];
+    const positions = included.filter(i => /\\.Position$/.test(i?.$type || ""));
+    return { raw, positionSample: positions.slice(0, 6) };
+  })()`);
+
+  const outDir = path.join(EXT_DIR, "test/fixtures/voyager/_captured");
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, `profile-${slug}.json`), JSON.stringify(out.raw, null, 2));
+  console.log(`✓ Wrote raw profile to _captured/profile-${slug}.json`);
+  console.log("\nPosition objects (company lives here):");
+  for (const p of out.positionSample) {
+    console.log(JSON.stringify({
+      companyName: p.companyName, title: p.title,
+      timePeriod: p.timePeriod, dateRange: p.dateRange,
+      company: p.company, keys: Object.keys(p),
+    }, null, 2));
+  }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+(async () => {
+  console.log(`PingCRM extension Layer 3 — mode: ${MODE}`);
+  const { proc, browserWs } = await launchChrome();
+  let browser;
+  try {
+    const conn = await connectBrowser(browserWs);
+    browser = conn.b;
+    console.log("→ Opening LinkedIn tab and injecting li_at...");
+    await openLinkedInTab(conn.b);
+    console.log("→ Attaching to extension service worker...");
+    const { evaluate } = await attachServiceWorker(conn.b, conn.targets);
+    if (MODE === "profile") await runProfileProbe(evaluate, PROFILE_SLUG);
+    else if (MODE === "capture") await runCapture(evaluate);
+    else await runE2E(evaluate);
+  } catch (e) {
+    console.error("✖", e.message);
+    process.exitCode = 1;
+  } finally {
+    browser?.close();
+    proc.kill();
+  }
+})();

--- a/chrome-extension/test/captured.smoke.test.mjs
+++ b/chrome-extension/test/captured.smoke.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * Layer 1.5 — run REAL captured Voyager data through the actual parsers.
+ *
+ * Bridges Layers 1 and 3: when a `--capture` run has produced
+ * fixtures/voyager/_captured/, this asserts the shipping parsers
+ * (_parseConversations / _parseParticipants / _parseMessages / _eventToMessage)
+ * still handle LinkedIn's *current* schema — i.e. the synthetic fixtures
+ * haven't drifted from reality.
+ *
+ * Skips automatically when no capture exists (e.g. in CI), so it never blocks
+ * the offline suite.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { makeChrome } from "./helpers/chrome-stub.mjs";
+import { loadModules, SYNC_FILES } from "./helpers/loader.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CAP = path.join(HERE, "fixtures/voyager/_captured");
+const hasCapture = fs.existsSync(path.join(CAP, "conversations.page1.json"));
+
+test("captured LinkedIn data parses into valid push messages", { skip: !hasCapture && "no capture present (run: npm run capture)" }, () => {
+  const convs = JSON.parse(fs.readFileSync(path.join(CAP, "conversations.page1.json"), "utf8"));
+  const selfUrn = JSON.parse(fs.readFileSync(path.join(CAP, "self-urn.json"), "utf8")).selfUrn;
+
+  const stub = makeChrome({ executeScript: async () => ({ ok: true, status: 200, data: {} }) });
+  const api = loadModules({
+    chrome: stub.chrome,
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+    files: SYNC_FILES,
+    exports: ["_parseConversations", "_parseParticipants", "_parseMessages", "_eventToMessage"],
+  });
+
+  const els = api._parseConversations(convs);
+  assert.ok(els.length > 0, "real conversations parsed");
+
+  const selfSuffix = selfUrn.split(":").pop();
+  let total = 0;
+  let named = 0;
+  for (const conv of els) {
+    const parts = api._parseParticipants(conv);
+    const other = parts.find((p) => (p.profileUrn || "").split(":").pop() !== selfSuffix) || parts[0];
+    const pubId = other?.publicIdentifier;
+    const name = [other?.firstName, other?.lastName].filter(Boolean).join(" ") || conv?.title?.text || pubId || "Unknown";
+    const events = api._parseMessages({ data: { messengerMessages: { elements: conv?.messages?.elements ?? [] } } });
+    for (const ev of events) {
+      const m = api._eventToMessage(ev, conv.entityUrn, pubId, name, selfSuffix);
+      total++;
+      if (m.profile_name && m.profile_name !== "Unknown") named++;
+      assert.ok(["inbound", "outbound"].includes(m.direction), "valid direction");
+      assert.equal(m.source, "voyager");
+      assert.ok(m.timestamp && !Number.isNaN(Date.parse(m.timestamp)), "valid ISO timestamp");
+      assert.ok(m.conversation_id, "has conversation_id");
+    }
+  }
+  assert.ok(total > 0, "at least one real message parsed");
+  // Most threads should resolve a human name; allow a few group/anonymized ones.
+  assert.ok(named / total >= 0.6, `name resolution healthy (${named}/${total})`);
+});

--- a/chrome-extension/test/fixtures/voyager/_captured/.gitignore
+++ b/chrome-extension/test/fixtures/voyager/_captured/.gitignore
@@ -1,0 +1,4 @@
+# Raw Voyager captures contain real LinkedIn data — never commit.
+# Sanitize and copy into the parent dir to update the offline fixtures.
+*
+!.gitignore

--- a/chrome-extension/test/fixtures/voyager/conversations.page1.json
+++ b/chrome-extension/test/fixtures/voyager/conversations.page1.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "messengerConversationsBySyncToken": {
+      "elements": [
+        {
+          "entityUrn": "urn:li:msg_conversation:CONV1",
+          "backendUrn": "urn:li:msg_conversation:CONV1",
+          "lastActivityAt": 1749990000000,
+          "title": { "text": "Partner One" },
+          "conversationUrl": { "url": "https://www.linkedin.com/messaging/thread/CONV1" },
+          "conversationParticipants": [
+            {
+              "hostIdentityUrn": "urn:li:fsd_profile:PARTNER1",
+              "participantType": {
+                "member": {
+                  "profileUrl": "https://www.linkedin.com/in/partner-one",
+                  "firstName": "Partner",
+                  "lastName": "One"
+                }
+              }
+            },
+            {
+              "hostIdentityUrn": "urn:li:fsd_profile:SELF123",
+              "participantType": {
+                "member": {
+                  "profileUrl": "https://www.linkedin.com/in/self-user",
+                  "firstName": "Self",
+                  "lastName": "User"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "entityUrn": "urn:li:msg_conversation:CONV2",
+          "backendUrn": "urn:li:msg_conversation:CONV2",
+          "lastActivityAt": 1749000000000,
+          "title": { "text": "Partner Two" },
+          "conversationUrl": { "url": "https://www.linkedin.com/messaging/thread/CONV2" },
+          "conversationParticipants": [
+            {
+              "hostIdentityUrn": "urn:li:fsd_profile:PARTNER2",
+              "participantType": {
+                "member": {
+                  "profileUrl": "https://www.linkedin.com/in/partner-two",
+                  "firstName": "Partner",
+                  "lastName": "Two"
+                }
+              }
+            },
+            {
+              "hostIdentityUrn": "urn:li:fsd_profile:SELF123",
+              "participantType": {
+                "member": {
+                  "profileUrl": "https://www.linkedin.com/in/self-user",
+                  "firstName": "Self",
+                  "lastName": "User"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/chrome-extension/test/fixtures/voyager/me.json
+++ b/chrome-extension/test/fixtures/voyager/me.json
@@ -1,0 +1,11 @@
+{
+  "included": [
+    {
+      "$type": "com.linkedin.voyager.identity.shared.MiniProfile",
+      "entityUrn": "urn:li:fsd_profile:SELF123",
+      "publicIdentifier": "self-user",
+      "firstName": "Self",
+      "lastName": "User"
+    }
+  ]
+}

--- a/chrome-extension/test/fixtures/voyager/messages.conv1.json
+++ b/chrome-extension/test/fixtures/voyager/messages.conv1.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "messengerMessagesByConversation": {
+      "elements": [
+        {
+          "entityUrn": "urn:li:msg_message:M1",
+          "deliveredAt": 1749980000000,
+          "body": { "text": "Hey, great to connect!" },
+          "sender": {
+            "hostIdentityUrn": "urn:li:fsd_profile:PARTNER1",
+            "memberProfile": {
+              "entityUrn": "urn:li:fsd_profile:PARTNER1",
+              "publicIdentifier": "partner-one",
+              "firstName": "Partner",
+              "lastName": "One"
+            }
+          }
+        },
+        {
+          "entityUrn": "urn:li:msg_message:M2",
+          "deliveredAt": 1749990000000,
+          "body": { "text": "Likewise! Let's catch up next week." },
+          "sender": {
+            "hostIdentityUrn": "urn:li:fsd_profile:SELF123",
+            "memberProfile": {
+              "entityUrn": "urn:li:fsd_profile:SELF123",
+              "publicIdentifier": "self-user",
+              "firstName": "Self",
+              "lastName": "User"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/chrome-extension/test/fixtures/voyager/messages.conv2.json
+++ b/chrome-extension/test/fixtures/voyager/messages.conv2.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "messengerMessagesByConversation": {
+      "elements": [
+        {
+          "entityUrn": "urn:li:msg_message:M3",
+          "deliveredAt": 1748990000000,
+          "body": { "text": "Thanks for the intro earlier." },
+          "sender": {
+            "hostIdentityUrn": "urn:li:fsd_profile:PARTNER2",
+            "memberProfile": {
+              "entityUrn": "urn:li:fsd_profile:PARTNER2",
+              "publicIdentifier": "partner-two",
+              "firstName": "Partner",
+              "lastName": "Two"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/chrome-extension/test/fixtures/voyager/profile.json
+++ b/chrome-extension/test/fixtures/voyager/profile.json
@@ -1,0 +1,35 @@
+{
+  "included": [
+    {
+      "$type": "com.linkedin.voyager.dash.identity.profile.Profile",
+      "entityUrn": "urn:li:fsd_profile:ACoTESTMEMBER1",
+      "firstName": "Partner",
+      "lastName": "One",
+      "headline": "COO at Acme",
+      "geoLocationName": "San Francisco Bay Area",
+      "profilePicture": {
+        "displayImageReference": {
+          "vectorImage": {
+            "rootUrl": "https://media.licdn.com/dms/image/test/",
+            "artifacts": [
+              { "fileIdentifyingUrlPathSegment": "100_100.jpg" },
+              { "fileIdentifyingUrlPathSegment": "800_800.jpg" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "$type": "com.linkedin.voyager.dash.identity.profile.Position",
+      "companyName": "Acme",
+      "title": "COO",
+      "dateRange": { "start": { "year": 2022, "month": 1 } }
+    },
+    {
+      "$type": "com.linkedin.voyager.dash.identity.profile.Position",
+      "companyName": "OldCo",
+      "title": "Engineer",
+      "dateRange": { "start": { "year": 2015 }, "end": { "year": 2020 } }
+    }
+  ]
+}

--- a/chrome-extension/test/helpers/chrome-stub.mjs
+++ b/chrome-extension/test/helpers/chrome-stub.mjs
@@ -1,0 +1,118 @@
+/**
+ * In-memory stub of the chrome.* extension APIs the service worker touches.
+ *
+ * This is the foundation for Layers 1 and 2: it replaces the only stateful
+ * browser surfaces (storage, cookies, tabs, scripting, action) with plain JS
+ * so the real extension code runs unmodified in Node.
+ *
+ * The single browser-coupled seam in the whole sync path is
+ * chrome.scripting.executeScript (Voyager calls run inside a LinkedIn tab).
+ * Pass an `executeScript` router to serve canned Voyager responses.
+ */
+
+/**
+ * @param {object}   opts
+ * @param {(args:any[]) => any}  opts.executeScript  Router for executeScript.
+ *        Receives the call's `args` array and returns the value the in-page
+ *        function would have returned (e.g. {ok, status, data} for Voyager).
+ * @param {Array<{name:string,value:string,domain?:string}>} [opts.cookies]
+ * @param {Array<{id:number,url:string,active?:boolean}>}    [opts.tabs]
+ * @param {object}   [opts.manifest]
+ */
+export function makeChrome({
+  executeScript = async () => ({ ok: false, status: 0, body: "NO_ROUTER" }),
+  cookies = [],
+  tabs = [{ id: 1, url: "https://www.linkedin.com/feed/", active: true }],
+  manifest = { version: "test" },
+} = {}) {
+  const store = new Map();
+  const badges = [];
+  const listeners = { message: [], installed: [], cookieChanged: [], tabUpdated: [] };
+
+  const localGet = (keys) => {
+    const out = {};
+    if (keys == null) {
+      for (const [k, v] of store) out[k] = v;
+    } else if (typeof keys === "string") {
+      if (store.has(keys)) out[keys] = store.get(keys);
+    } else if (Array.isArray(keys)) {
+      for (const k of keys) if (store.has(k)) out[k] = store.get(k);
+    } else {
+      for (const k of Object.keys(keys)) out[k] = store.has(k) ? store.get(k) : keys[k];
+    }
+    return Promise.resolve(out);
+  };
+  const localSet = (obj) => {
+    for (const k of Object.keys(obj)) store.set(k, obj[k]);
+    return Promise.resolve();
+  };
+  const localRemove = (keys) => {
+    for (const k of Array.isArray(keys) ? keys : [keys]) store.delete(k);
+    return Promise.resolve();
+  };
+  const localClear = () => {
+    store.clear();
+    return Promise.resolve();
+  };
+
+  const matchTab = (pattern) => {
+    if (!pattern) return tabs;
+    // crude chrome match-pattern: "https://www.linkedin.com/*"
+    const re = new RegExp("^" + pattern.replace(/[.]/g, "\\.").replace(/\*/g, ".*"));
+    return tabs.filter((t) => re.test(t.url));
+  };
+
+  const chrome = {
+    runtime: {
+      getManifest: () => manifest,
+      onMessage: { addListener: (fn) => listeners.message.push(fn) },
+      onInstalled: { addListener: (fn) => listeners.installed.push(fn) },
+    },
+    storage: {
+      local: { get: localGet, set: localSet, remove: localRemove, clear: localClear },
+    },
+    cookies: {
+      getAll: async (q) =>
+        cookies.filter((c) => !q?.domain || (c.domain ?? ".linkedin.com").includes(q.domain.replace(/^\./, ""))),
+      get: async ({ name }) => cookies.find((c) => c.name === name) ?? null,
+      onChanged: { addListener: (fn) => listeners.cookieChanged.push(fn) },
+    },
+    tabs: {
+      query: async (q) => matchTab(q?.url),
+      create: async (p) => {
+        const t = { id: tabs.length + 1, active: true, ...p };
+        tabs.push(t);
+        return t;
+      },
+      remove: async () => {},
+      onUpdated: {
+        addListener: (fn) => listeners.tabUpdated.push(fn),
+        removeListener: () => {},
+      },
+    },
+    scripting: {
+      executeScript: async ({ args }) => [{ result: await executeScript(args) }],
+    },
+    action: {
+      setBadgeText: ({ text }) => badges.push(text),
+      setBadgeBackgroundColor: () => {},
+    },
+  };
+
+  /** Drive the SW's onMessage router and resolve with its sendResponse value. */
+  const sendMessage = (msg, sender = {}) =>
+    new Promise((resolve) => {
+      let answered = false;
+      const sendResponse = (r) => {
+        answered = true;
+        resolve(r);
+      };
+      for (const fn of listeners.message) {
+        const ret = fn(msg, sender, sendResponse);
+        if (ret === true) return; // async: sendResponse will fire later
+      }
+      if (!answered) resolve(undefined);
+    });
+
+  return { chrome, store, badges, listeners, tabs, sendMessage };
+}

--- a/chrome-extension/test/helpers/fake-backend.mjs
+++ b/chrome-extension/test/helpers/fake-backend.mjs
@@ -1,0 +1,65 @@
+/**
+ * A fetch() replacement that records every request and returns canned
+ * PingCRM backend responses. Used by Layers 1 and 2 to run fully offline.
+ *
+ * To test against a *real* local backend instead, skip this and pass Node's
+ * global fetch with a real apiUrl + extension token (see test/README.md).
+ */
+
+function jsonResponse(status, obj) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => obj,
+    text: async () => JSON.stringify(obj),
+  };
+}
+
+/**
+ * @param {object} [opts]
+ * @param {object} [opts.pushData]   `data` payload for /linkedin/push (envelope-wrapped)
+ * @param {number} [opts.pushStatus] HTTP status for /linkedin/push (default 200)
+ */
+export function makeFakeBackend({ pushData, pushStatus = 200 } = {}) {
+  const requests = [];
+
+  const fetchImpl = async (url, opts = {}) => {
+    const entry = {
+      url,
+      method: opts.method ?? "GET",
+      headers: opts.headers ?? {},
+      body: opts.body ? safeParse(opts.body) : null,
+    };
+    requests.push(entry);
+
+    if (url.includes("/api/v1/linkedin/push")) {
+      const data = pushData ?? {
+        contacts_created: 0,
+        contacts_updated: 0,
+        interactions_created: 0,
+        interactions_skipped: 0,
+        backfill_needed: [],
+      };
+      return jsonResponse(pushStatus, { data });
+    }
+    if (url.includes("/api/v1/extension/refresh")) {
+      return jsonResponse(200, { data: { token: "refreshed-token" } });
+    }
+    if (url.includes("/api/v1/extension/pair")) {
+      const base = url.split("/api/v1/")[0];
+      return jsonResponse(200, { data: { token: "paired-token", api_url: base } });
+    }
+    return jsonResponse(404, { error: { message: "no fake route" } });
+  };
+
+  const pushes = () => requests.filter((r) => r.url.includes("/linkedin/push"));
+  return { fetchImpl, requests, pushes };
+}
+
+function safeParse(body) {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return body;
+  }
+}

--- a/chrome-extension/test/helpers/loader.mjs
+++ b/chrome-extension/test/helpers/loader.mjs
@@ -1,0 +1,99 @@
+/**
+ * Loads the real extension service-worker modules into a Node vm context.
+ *
+ * The modules are classic scripts meant for importScripts() — they share one
+ * global lexical scope and expose functions as globals. We reproduce that by
+ * concatenating the sources and running them as a single script in a vm
+ * context whose globals are our stubs (chrome, fetch, Date, crypto, ...).
+ *
+ * importScripts() inside service-worker.js is neutralized (no-op) because we
+ * concatenate its dependencies ourselves, in the same order it lists them.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const EXT_DIR = path.resolve(HERE, "../..");
+const BG = path.join(EXT_DIR, "background");
+const LIB = path.join(EXT_DIR, "lib");
+
+/** The exact importScripts() order from service-worker.js, then the SW itself. */
+export const SERVICE_WORKER_FILES = [
+  path.join(LIB, "storage.js"),
+  path.join(BG, "voyager-client.js"),
+  path.join(BG, "sync-utils.js"),
+  path.join(BG, "sync.js"),
+  path.join(BG, "pairing.js"),
+  path.join(BG, "meta-client.js"),
+  path.join(BG, "meta-sync-utils.js"),
+  path.join(BG, "sync-facebook.js"),
+  path.join(BG, "sync-instagram.js"),
+  path.join(BG, "twitter-sync.js"),
+  path.join(BG, "service-worker.js"),
+];
+
+/** Just the LinkedIn sync pipeline — enough for Layer 1 logic tests. */
+export const SYNC_FILES = [
+  path.join(LIB, "storage.js"),
+  path.join(BG, "voyager-client.js"),
+  path.join(BG, "sync-utils.js"),
+  path.join(BG, "sync.js"),
+  path.join(BG, "pairing.js"),
+];
+
+/**
+ * @param {object} opts
+ * @param {object} opts.chrome      chrome stub from makeChrome()
+ * @param {Function} opts.fetchImpl global fetch replacement
+ * @param {string[]} opts.files     module paths to concatenate (in order)
+ * @param {number} [opts.fixedNow]  freeze Date.now() to this epoch ms (determinism)
+ * @param {string[]} [opts.exports] global names to expose on the returned object
+ * @returns {object} the vm sandbox; requested exports are also returned at top level
+ */
+export function loadModules({ chrome, fetchImpl, files, fixedNow, exports = [] }) {
+  const RealDate = Date;
+  function FixedDate(...a) {
+    return a.length ? new RealDate(...a) : new RealDate(fixedNow);
+  }
+  FixedDate.now = () => fixedNow;
+  FixedDate.parse = RealDate.parse;
+  FixedDate.UTC = RealDate.UTC;
+  FixedDate.prototype = RealDate.prototype;
+
+  // Resolve delays immediately so 1s rate-limit pauses don't slow tests.
+  const fastTimeout = (fn) => {
+    Promise.resolve().then(fn);
+    return 0;
+  };
+
+  const sandbox = {
+    chrome,
+    fetch: fetchImpl,
+    console,
+    crypto: globalThis.crypto,
+    setTimeout: fastTimeout,
+    clearTimeout: () => {},
+    setInterval: () => 0, // pairing poll loop never fires under test
+    clearInterval: () => {},
+    Date: fixedNow ? FixedDate : Date,
+    TextEncoder,
+    TextDecoder,
+    URL,
+    URLSearchParams,
+    structuredClone,
+    importScripts: () => {}, // neutralized — we concatenate manually
+  };
+  sandbox.self = sandbox;
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+
+  let src = files.map((f) => fs.readFileSync(f, "utf8")).join("\n;\n");
+  if (exports.length) {
+    src += `\n;globalThis.__exports = { ${exports.join(", ")} };`;
+  }
+  vm.runInContext(src, sandbox, { filename: "sw-bundle.js" });
+
+  return Object.assign(sandbox, sandbox.__exports ?? {});
+}

--- a/chrome-extension/test/helpers/voyager-router.mjs
+++ b/chrome-extension/test/helpers/voyager-router.mjs
@@ -1,0 +1,65 @@
+/**
+ * Maps an executeScript Voyager call to a canned fixture, mimicking what the
+ * in-page fetch would have returned. This is the seam that lets the whole sync
+ * pipeline run without a browser or a real LinkedIn session.
+ *
+ * The default fixtures live in test/fixtures/voyager/. Capture real ones from a
+ * live session with `node test/capture-and-e2e.mjs --capture` (see README).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIX = path.resolve(HERE, "../fixtures/voyager");
+
+const read = (name) => JSON.parse(fs.readFileSync(path.join(FIX, name), "utf8"));
+
+export function loadFixtures() {
+  return {
+    me: read("me.json"),
+    conversations: read("conversations.page1.json"),
+    conversationsEmpty: { data: { messengerConversationsBySyncToken: { elements: [] } } },
+    messagesConv1: read("messages.conv1.json"),
+    messagesConv2: read("messages.conv2.json"),
+    profile: read("profile.json"),
+  };
+}
+
+const ok = (data) => ({ ok: true, status: 200, data });
+
+/**
+ * Build an executeScript router over a fixture set.
+ * @param {ReturnType<typeof loadFixtures>} [fixtures]
+ */
+export function makeVoyagerRouter(fixtures = loadFixtures()) {
+  return async (args) => {
+    // Image fetch path: func(imgUrl, maxBytes) — args[1] is a number.
+    if (args.length === 2 && typeof args[1] === "number") {
+      return { ok: true, dataUrl: "data:image/jpeg;base64,/9j/stub", via: "stub" };
+    }
+
+    const url = String(args[0] ?? "");
+
+    if (url.includes("/voyager/api/me")) return ok(fixtures.me);
+
+    if (url.includes("voyagerMessagingGraphQL")) {
+      const rawVars = url.split("variables=")[1] ?? "";
+      const variables = decodeURIComponent(rawVars);
+
+      if (url.includes("messengerConversations")) {
+        return ok(variables.includes("lastUpdatedBefore") ? fixtures.conversationsEmpty : fixtures.conversations);
+      }
+      if (url.includes("messengerMessages")) {
+        const convUrn = variables.match(/conversationUrn:([^,)]+)/)?.[1] ?? "";
+        if (convUrn.includes("CONV1")) return ok(fixtures.messagesConv1);
+        if (convUrn.includes("CONV2")) return ok(fixtures.messagesConv2);
+        return ok({ data: { messengerMessagesByConversation: { elements: [] } } });
+      }
+    }
+
+    if (url.includes("/identity/dash/profiles")) return ok(fixtures.profile);
+
+    return { ok: false, status: 404, body: "NO_FIXTURE: " + url };
+  };
+}

--- a/chrome-extension/test/layer1.logic.test.mjs
+++ b/chrome-extension/test/layer1.logic.test.mjs
@@ -1,0 +1,137 @@
+/**
+ * Layer 1 — offline logic harness.
+ *
+ * Drives the real runSync() pipeline with mocked executeScript (Voyager
+ * fixtures) and a fake backend. No browser, no cookies, no LinkedIn session.
+ * Catches the bugs the integration memo flags: direction, dedup/watermark
+ * delta, transform shape. Run: `node --test`.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeChrome } from "./helpers/chrome-stub.mjs";
+import { makeFakeBackend } from "./helpers/fake-backend.mjs";
+import { makeVoyagerRouter } from "./helpers/voyager-router.mjs";
+import { loadModules, SYNC_FILES } from "./helpers/loader.mjs";
+
+const FIXED_NOW = 1750000000000; // freeze Date.now() for deterministic cutoffs
+const ONE_DAY = 86_400_000;
+const LINKEDIN_COOKIES = [
+  { name: "li_at", value: "li-at-stub", domain: ".linkedin.com" },
+  { name: "JSESSIONID", value: '"ajax:1234"', domain: ".linkedin.com" },
+];
+
+/** Build a fully-wired offline harness. `seed` pre-populates chrome.storage. */
+function harness({ seed = {}, cookies = LINKEDIN_COOKIES, tabs, backend = {} } = {}) {
+  const fake = makeFakeBackend(backend);
+  const stub = makeChrome({ executeScript: makeVoyagerRouter(), cookies, tabs });
+  for (const [k, v] of Object.entries(seed)) stub.store.set(k, v);
+  const api = loadModules({
+    chrome: stub.chrome,
+    fetchImpl: fake.fetchImpl,
+    files: SYNC_FILES,
+    fixedNow: FIXED_NOW,
+    exports: ["runSync", "generatePairingCode"],
+  });
+  return { ...stub, ...fake, api };
+}
+
+test("first sync: fetches both conversations and pushes all 3 messages", async () => {
+  const h = harness({ seed: { apiUrl: "http://localhost:8000", token: "tok" } });
+
+  const result = await h.api.runSync("http://localhost:8000", "tok", true);
+
+  assert.equal(result.error, null);
+  assert.equal(result.conversations, 2);
+  assert.equal(result.messages, 3);
+
+  const push = h.pushes().at(-1);
+  assert.ok(push, "a /linkedin/push request was made");
+  assert.equal(push.body.messages.length, 3);
+  assert.equal(push.headers.Authorization, "Bearer tok");
+});
+
+test("direction is derived from self URN, not partner", async () => {
+  const h = harness({ seed: { apiUrl: "http://x", token: "t" } });
+  await h.api.runSync("http://x", "t", true);
+
+  const msgs = h.pushes().at(-1).body.messages;
+  const m1 = msgs.find((m) => m.raw_reference_id.includes("M1"));
+  const m2 = msgs.find((m) => m.raw_reference_id.includes("M2"));
+
+  assert.equal(m1.direction, "inbound", "M1 sent by PARTNER1 → inbound");
+  assert.equal(m2.direction, "outbound", "M2 sent by SELF123 → outbound");
+});
+
+test("push payload shape matches /linkedin/push contract", async () => {
+  const h = harness({ seed: { apiUrl: "http://x", token: "t" } });
+  await h.api.runSync("http://x", "t", true);
+
+  const msg = h.pushes().at(-1).body.messages[0];
+  for (const k of ["conversation_id", "profile_id", "profile_name", "direction", "content_preview", "timestamp", "source", "raw_reference_id"]) {
+    assert.ok(k in msg, `message has ${k}`);
+  }
+  assert.equal(msg.source, "voyager");
+  assert.equal(msg.profile_name, "Partner One");
+  assert.match(msg.timestamp, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("delta sync: watermark skips the stale conversation and old messages", async () => {
+  const watermark = new Date(FIXED_NOW - ONE_DAY).toISOString();
+  const h = harness({ seed: { apiUrl: "http://x", token: "t", watermark } });
+
+  const result = await h.api.runSync("http://x", "t", true);
+
+  // CONV2 (last activity 11 days ago) is older than the watermark → skipped.
+  // CONV1's two messages are both newer than the watermark → kept.
+  assert.equal(result.messages, 2, "only CONV1 messages survive the delta cutoff");
+  const ids = h.pushes().at(-1).body.messages.map((m) => m.raw_reference_id);
+  assert.ok(ids.every((id) => !id.includes("M3")), "stale CONV2 message excluded");
+});
+
+test("watermark advances to the newest processed message", async () => {
+  const h = harness({ seed: { apiUrl: "http://x", token: "t" } });
+  await h.api.runSync("http://x", "t", true);
+
+  // newest message is M2 @ 1749990000000
+  assert.equal(h.store.get("watermark"), new Date(1749990000000).toISOString());
+  assert.ok(h.store.get("lastVoyagerSync"), "sync timestamp persisted");
+});
+
+test("missing cookies → MISSING_COOKIES, cookiesValid=false, no push", async () => {
+  const h = harness({ seed: { apiUrl: "http://x", token: "t" }, cookies: [] });
+
+  const result = await h.api.runSync("http://x", "t", true);
+
+  assert.equal(result.error, "MISSING_COOKIES");
+  assert.equal(h.store.get("cookiesValid"), false);
+  assert.equal(h.pushes().length, 0);
+});
+
+test("no LinkedIn tab → NO_LINKEDIN_TAB surfaced (not a crash)", async () => {
+  const h = harness({ seed: { apiUrl: "http://x", token: "t" }, tabs: [] });
+
+  const result = await h.api.runSync("http://x", "t", true);
+
+  assert.equal(result.error, "NO_LINKEDIN_TAB");
+});
+
+test("backend 401 then successful silent refresh re-pushes with new token", async () => {
+  // First push 401s; sync calls /extension/refresh (fake → 'refreshed-token'),
+  // then retries the push. With our fake backend the retry also 401s, so the
+  // token is cleared — assert the refresh was at least attempted.
+  const h = harness({
+    seed: { apiUrl: "http://x", token: "stale" },
+    backend: { pushStatus: 401 },
+  });
+
+  const result = await h.api.runSync("http://x", "t", true);
+
+  assert.ok(h.requests.some((r) => r.url.includes("/extension/refresh")), "attempted silent refresh on 401");
+  assert.equal(result.error, "AUTH_EXPIRED");
+});
+
+test("pairing code generator produces a valid PING- code", async () => {
+  const h = harness();
+  const code = h.api.generatePairingCode();
+  assert.match(code, /^PING-[ABCDEFGHJKMNPQRSTUVWXYZ23456789]{6}$/);
+});

--- a/chrome-extension/test/layer2.router.test.mjs
+++ b/chrome-extension/test/layer2.router.test.mjs
@@ -1,0 +1,87 @@
+/**
+ * Layer 2 — full message-router harness.
+ *
+ * Loads the REAL service-worker.js (and everything it importScripts) and drives
+ * it by dispatching the same message objects the popup sends — SYNC_NOW,
+ * START_PAIRING, DISCONNECT — observing outgoing fetches and badge updates.
+ * This exercises the actual router + module wiring, not a reimplementation.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeChrome } from "./helpers/chrome-stub.mjs";
+import { makeFakeBackend } from "./helpers/fake-backend.mjs";
+import { makeVoyagerRouter } from "./helpers/voyager-router.mjs";
+import { loadModules, SERVICE_WORKER_FILES } from "./helpers/loader.mjs";
+
+const FIXED_NOW = 1750000000000;
+const LINKEDIN_COOKIES = [
+  { name: "li_at", value: "li-at-stub", domain: ".linkedin.com" },
+  { name: "JSESSIONID", value: '"ajax:1234"', domain: ".linkedin.com" },
+];
+
+function serviceWorker({ seed = {}, cookies = LINKEDIN_COOKIES, tabs, backend = {} } = {}) {
+  const fake = makeFakeBackend(backend);
+  const stub = makeChrome({ executeScript: makeVoyagerRouter(), cookies, tabs });
+  for (const [k, v] of Object.entries(seed)) stub.store.set(k, v);
+  // Loading registers the SW's onMessage listener via the chrome stub.
+  loadModules({
+    chrome: stub.chrome,
+    fetchImpl: fake.fetchImpl,
+    files: SERVICE_WORKER_FILES,
+    fixedNow: FIXED_NOW,
+  });
+  return { ...stub, ...fake };
+}
+
+test("service worker boots and registers a message listener", () => {
+  const sw = serviceWorker();
+  assert.equal(sw.listeners.message.length, 1, "exactly one onMessage router");
+});
+
+test("SYNC_NOW (paired) runs a full sync and responds with counts", async () => {
+  const sw = serviceWorker({ seed: { apiUrl: "http://localhost:8000", token: "tok" } });
+
+  const resp = await sw.sendMessage({ type: "SYNC_NOW" });
+
+  assert.equal(resp.ok, true);
+  assert.equal(resp.conversations, 2);
+  assert.equal(resp.messages, 3);
+  assert.ok(sw.badges.includes("OK"), "success badge set");
+  assert.ok(sw.pushes().length >= 1, "pushed to backend");
+});
+
+test("SYNC_NOW (unpaired) responds Not paired without touching the network", async () => {
+  const sw = serviceWorker(); // empty store
+
+  const resp = await sw.sendMessage({ type: "SYNC_NOW" });
+
+  assert.equal(resp.ok, false);
+  assert.equal(resp.error, "Not paired");
+  assert.equal(sw.pushes().length, 0);
+});
+
+test("START_PAIRING saves the instance URL and returns a pairing code", async () => {
+  const sw = serviceWorker();
+
+  const resp = await sw.sendMessage({ type: "START_PAIRING", apiUrl: "http://localhost:8000/" });
+
+  assert.equal(resp.ok, true);
+  assert.match(resp.code, /^PING-[A-Z2-9]{6}$/);
+  assert.equal(sw.store.get("apiUrl"), "http://localhost:8000", "trailing slash stripped + persisted");
+});
+
+test("START_PAIRING with no URL is rejected", async () => {
+  const sw = serviceWorker();
+  const resp = await sw.sendMessage({ type: "START_PAIRING", apiUrl: "" });
+  assert.equal(resp.ok, false);
+  assert.equal(resp.error, "Instance URL is required");
+});
+
+test("DISCONNECT clears storage and reports success", async () => {
+  const sw = serviceWorker({ seed: { apiUrl: "http://x", token: "tok", watermark: "2026-01-01T00:00:00Z" } });
+
+  const resp = await sw.sendMessage({ type: "DISCONNECT" });
+
+  assert.equal(resp.ok, true);
+  assert.equal(sw.store.size, 0, "all storage cleared");
+});

--- a/chrome-extension/test/package.json
+++ b/chrome-extension/test/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pingcrm-extension-tests",
+  "private": true,
+  "type": "module",
+  "description": "Offline + scripted harness for debugging the PingCRM companion extension without a manual browser session.",
+  "scripts": {
+    "test": "node --test \"**/*.test.mjs\"",
+    "test:watch": "node --test --watch \"**/*.test.mjs\"",
+    "capture": "node capture-and-e2e.mjs --capture",
+    "e2e": "node capture-and-e2e.mjs --e2e"
+  }
+}

--- a/chrome-extension/test/profile-capture.test.mjs
+++ b/chrome-extension/test/profile-capture.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * Tests for profile-visit capture (the avatar/company enrichment fix).
+ *
+ *  Layer 1 — _extractProfileFields against synthetic + real captured profiles.
+ *  Layer 2 — the PROFILE_VISIT service-worker handler end to end (mocked Voyager
+ *            + fake backend), asserting the enrich_only push carries company and
+ *            the member_id needed to repair ACo-anonymized contacts.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { makeChrome } from "./helpers/chrome-stub.mjs";
+import { makeFakeBackend } from "./helpers/fake-backend.mjs";
+import { makeVoyagerRouter } from "./helpers/voyager-router.mjs";
+import { loadModules, SYNC_FILES, SERVICE_WORKER_FILES } from "./helpers/loader.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXED_NOW = 1750000000000;
+const COOKIES = [
+  { name: "li_at", value: "li-at-stub", domain: ".linkedin.com" },
+  { name: "JSESSIONID", value: '"ajax:1234"', domain: ".linkedin.com" },
+];
+
+// ── Layer 1: the extractor ───────────────────────────────────────────────────
+function extractor() {
+  const stub = makeChrome({ executeScript: async () => ({ ok: true, status: 200, data: {} }) });
+  return loadModules({
+    chrome: stub.chrome,
+    fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+    files: SYNC_FILES,
+    exports: ["_extractProfileFields"],
+  })._extractProfileFields;
+}
+
+test("_extractProfileFields pulls company from the current position", () => {
+  const raw = JSON.parse(fs.readFileSync(path.join(HERE, "fixtures/voyager/profile.json"), "utf8"));
+  const f = extractor()(raw);
+
+  assert.equal(f.memberId, "ACoTESTMEMBER1");
+  assert.equal(f.fullName, "Partner One");
+  assert.equal(f.company, "Acme", "current position (no end date) wins over OldCo");
+  assert.equal(f.headline, "COO at Acme");
+  assert.equal(f.location, "San Francisco Bay Area");
+  assert.equal(f.avatarUrl, "https://media.licdn.com/dms/image/test/800_800.jpg", "largest artifact");
+});
+
+test("_extractProfileFields returns null when no profile object present", () => {
+  assert.equal(extractor()({ included: [] }), null);
+});
+
+const captured = path.join(HERE, "fixtures/voyager/_captured/profile-mattjlam.json");
+test("_extractProfileFields handles real captured profile", { skip: !fs.existsSync(captured) && "no capture present" }, () => {
+  const raw = JSON.parse(fs.readFileSync(captured, "utf8"));
+  const f = extractor()(raw);
+  assert.ok(f, "extracted a profile");
+  assert.match(f.memberId, /^ACo/, "member id from URN");
+  assert.ok(f.company, "a current company was resolved");
+  assert.match(f.avatarUrl, /media\.licdn\.com/, "avatar url resolved");
+});
+
+// ── Layer 2: the PROFILE_VISIT handler ───────────────────────────────────────
+function serviceWorker({ seed = {}, cookies = COOKIES } = {}) {
+  const fake = makeFakeBackend();
+  const stub = makeChrome({ executeScript: makeVoyagerRouter(), cookies });
+  for (const [k, v] of Object.entries(seed)) stub.store.set(k, v);
+  loadModules({
+    chrome: stub.chrome,
+    fetchImpl: fake.fetchImpl,
+    files: SERVICE_WORKER_FILES,
+    fixedNow: FIXED_NOW,
+  });
+  return { ...stub, ...fake };
+}
+
+test("PROFILE_VISIT enriches an existing contact with company + member_id", async () => {
+  const sw = serviceWorker({ seed: { apiUrl: "http://localhost:8000", token: "tok" } });
+
+  const resp = await sw.sendMessage({ type: "PROFILE_VISIT", slug: "mattjlam" });
+
+  assert.equal(resp.ok, true);
+  assert.equal(resp.company, "Acme");
+  assert.equal(resp.avatar, true);
+
+  const push = sw.pushes().at(-1);
+  assert.ok(push, "pushed to /linkedin/push");
+  assert.equal(push.body.enrich_only, true, "enrich-only so it never creates strangers");
+  const p = push.body.profiles[0];
+  assert.equal(p.profile_id, "mattjlam");
+  assert.equal(p.member_id, "ACoTESTMEMBER1", "ACo id sent so backend can repair the contact");
+  assert.equal(p.company, "Acme");
+  assert.equal(p.profile_url, "https://www.linkedin.com/in/mattjlam");
+  assert.ok(p.avatar_data, "avatar bytes attached");
+});
+
+test("PROFILE_VISIT rejects ACo member-id slugs (no usable public slug)", async () => {
+  const sw = serviceWorker({ seed: { apiUrl: "http://x", token: "t" } });
+  const resp = await sw.sendMessage({ type: "PROFILE_VISIT", slug: "ACoAAAFS80wB" });
+  assert.equal(resp.ok, false);
+  assert.equal(resp.error, "NO_SLUG");
+  assert.equal(sw.pushes().length, 0);
+});
+
+test("PROFILE_VISIT is throttled per slug", async () => {
+  const sw = serviceWorker({ seed: { apiUrl: "http://x", token: "t" } });
+
+  const first = await sw.sendMessage({ type: "PROFILE_VISIT", slug: "mattjlam" });
+  const second = await sw.sendMessage({ type: "PROFILE_VISIT", slug: "mattjlam" });
+
+  assert.equal(first.ok, true);
+  assert.equal(second.throttled, true);
+  assert.equal(sw.pushes().length, 1, "second visit within window does not re-push");
+});
+
+test("PROFILE_VISIT requires pairing", async () => {
+  const sw = serviceWorker(); // empty store
+  const resp = await sw.sendMessage({ type: "PROFILE_VISIT", slug: "mattjlam" });
+  assert.equal(resp.ok, false);
+  assert.equal(resp.error, "Not paired");
+  assert.equal(sw.pushes().length, 0);
+});

--- a/docs/docs/features/linkedin.md
+++ b/docs/docs/features/linkedin.md
@@ -74,9 +74,15 @@ When the composer toolbar is detected, the content script asks the service worke
 
 ## Profile Backfill
 
-After each sync, the backend identifies contacts missing a job title, company, or avatar. The extension then fetches those profiles via the Voyager API and pushes the enriched data back — up to 10 profiles per sync cycle. No manual profile visits required.
+After each sync, the backend identifies contacts missing a job title, company, or avatar. The extension then fetches those profiles via the Voyager API and pushes the enriched data back — up to 10 profiles per sync cycle. The current company is read from the profile's active position (the experience with no end date), and the avatar CDN URL is fetched as image bytes inside the LinkedIn tab (the backend can't download from LinkedIn's CDN directly).
 
-Voyager profile responses include CDN URLs for profile photos at multiple resolutions. The backend downloads the images server-side, so contacts you've messaged but never visited on LinkedIn receive avatars automatically.
+Backfill can only enrich contacts whose `linkedin_profile_id` is a public slug. Contacts created from DMs are often keyed on an **anonymized member id** (`ACo…`), which the profile endpoint rejects — those are skipped by backfill and enriched via profile visits instead (below).
+
+## Profile-Visit Enrichment
+
+When you open someone's LinkedIn profile (`/in/<slug>`), the extension fetches that person via the Voyager API and pushes their avatar, current company, headline, and location to the backend. The push includes both the public slug **and** the member id, so the backend can match a contact that was created from a DM under an anonymized `ACo…` id, enrich it, and upgrade its stored identity to the real slug.
+
+This path is **enrichment-only**: opening the profile of someone who isn't already a contact does not create a new CRM entry. Each profile is fetched at most once per 10 minutes.
 
 ## Importing Full History
 

--- a/frontend/src/lib/api-types.d.ts
+++ b/frontend/src/lib/api-types.d.ts
@@ -2642,9 +2642,7 @@ export interface components {
         /** CsvImportResult */
         CsvImportResult: {
             /** Created */
-            created: {
-                [key: string]: unknown;
-            }[];
+            created: Record<string, never>[];
             /** Errors */
             errors: string[];
         };
@@ -2708,9 +2706,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[ApplyTagsResult] */
         Envelope_ApplyTagsResult_: {
@@ -2718,9 +2714,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[AutoTagResult] */
         Envelope_AutoTagResult_: {
@@ -2728,9 +2722,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[AvatarRefreshData] */
         Envelope_AvatarRefreshData_: {
@@ -2738,9 +2730,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[BioRefreshData] */
         Envelope_BioRefreshData_: {
@@ -2748,9 +2738,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[ContactResponse] */
         Envelope_ContactResponse_: {
@@ -2758,9 +2746,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[ContactStatsData] */
         Envelope_ContactStatsData_: {
@@ -2768,9 +2754,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[CsvImportResult] */
         Envelope_CsvImportResult_: {
@@ -2778,9 +2762,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[DeletedData] */
         Envelope_DeletedData_: {
@@ -2788,9 +2770,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[DismissOrgMatchResult] */
         Envelope_DismissOrgMatchResult_: {
@@ -2798,9 +2778,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[EnrichData] */
         Envelope_EnrichData_: {
@@ -2808,9 +2786,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[FollowUpResponse] */
         Envelope_FollowUpResponse_: {
@@ -2818,9 +2794,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[IdentityMatchData] */
         Envelope_IdentityMatchData_: {
@@ -2828,9 +2802,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[InteractionResponse] */
         Envelope_InteractionResponse_: {
@@ -2838,9 +2810,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[LinkedInImportResult] */
         Envelope_LinkedInImportResult_: {
@@ -2848,9 +2818,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[LinkedInMessagesImportResult] */
         Envelope_LinkedInMessagesImportResult_: {
@@ -2858,9 +2826,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[LinkedInPushResult] */
         Envelope_LinkedInPushResult_: {
@@ -2868,9 +2834,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[MapConfig] */
         Envelope_MapConfig_: {
@@ -2878,9 +2842,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[MarkedData] */
         Envelope_MarkedData_: {
@@ -2888,9 +2850,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[McpKeyData] */
         Envelope_McpKeyData_: {
@@ -2898,9 +2858,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[McpKeyRevokedData] */
         Envelope_McpKeyRevokedData_: {
@@ -2908,9 +2866,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[McpKeyStatusData] */
         Envelope_McpKeyStatusData_: {
@@ -2918,9 +2874,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[MergeOrgMatchResult] */
         Envelope_MergeOrgMatchResult_: {
@@ -2928,9 +2882,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[MergeOrganizationsResult] */
         Envelope_MergeOrganizationsResult_: {
@@ -2938,9 +2890,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[MergedContactData] */
         Envelope_MergedContactData_: {
@@ -2948,9 +2898,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[MetaPushResult] */
         Envelope_MetaPushResult_: {
@@ -2958,9 +2906,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[NotificationReadData] */
         Envelope_NotificationReadData_: {
@@ -2968,9 +2914,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[OAuthUrlData] */
         Envelope_OAuthUrlData_: {
@@ -2978,9 +2922,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[OrgStatsResponse] */
         Envelope_OrgStatsResponse_: {
@@ -2988,9 +2930,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[OrganizationResponse] */
         Envelope_OrganizationResponse_: {
@@ -2998,9 +2938,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[PairTokenResponse] */
         Envelope_PairTokenResponse_: {
@@ -3008,9 +2946,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[PrioritySettingsData] */
         Envelope_PrioritySettingsData_: {
@@ -3018,9 +2954,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[RegenerateResult] */
         Envelope_RegenerateResult_: {
@@ -3028,9 +2962,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[ScanOrgsResult] */
         Envelope_ScanOrgsResult_: {
@@ -3038,9 +2970,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[ScanResultData] */
         Envelope_ScanResultData_: {
@@ -3048,9 +2978,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[ScoresRecalculatedData] */
         Envelope_ScoresRecalculatedData_: {
@@ -3058,9 +2986,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[SendMessageData] */
         Envelope_SendMessageData_: {
@@ -3068,9 +2994,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[SuggestionPrefsData] */
         Envelope_SuggestionPrefsData_: {
@@ -3078,9 +3002,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[SyncSettingsData] */
         Envelope_SyncSettingsData_: {
@@ -3088,9 +3010,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[SyncStartedData] */
         Envelope_SyncStartedData_: {
@@ -3098,9 +3018,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TaxonomyResult] */
         Envelope_TaxonomyResult_: {
@@ -3108,9 +3026,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TelegramConnectData] */
         Envelope_TelegramConnectData_: {
@@ -3118,9 +3034,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TelegramConnectedData] */
         Envelope_TelegramConnectedData_: {
@@ -3128,9 +3042,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TelegramSettingsData] */
         Envelope_TelegramSettingsData_: {
@@ -3138,9 +3050,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TelegramVerifyData] */
         Envelope_TelegramVerifyData_: {
@@ -3148,9 +3058,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TokenData] */
         Envelope_TokenData_: {
@@ -3158,9 +3066,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TwitterAuthUrlData] */
         Envelope_TwitterAuthUrlData_: {
@@ -3168,9 +3074,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TwitterBirdStatusData] */
         Envelope_TwitterBirdStatusData_: {
@@ -3178,9 +3082,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[TwitterConnectedData] */
         Envelope_TwitterConnectedData_: {
@@ -3188,9 +3090,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[UnreadCountData] */
         Envelope_UnreadCountData_: {
@@ -3198,9 +3098,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[UserResponse] */
         Envelope_UserResponse_: {
@@ -3208,9 +3106,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[UserWithAccountsData] */
         Envelope_UserWithAccountsData_: {
@@ -3218,9 +3114,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[VersionData] */
         Envelope_VersionData_: {
@@ -3228,9 +3122,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[WhatsAppSessionData] */
         Envelope_WhatsAppSessionData_: {
@@ -3238,9 +3130,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[WhatsAppStatusData] */
         Envelope_WhatsAppStatusData_: {
@@ -3248,22 +3138,16 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[dict] */
         Envelope_dict_: {
             /** Data */
-            data?: {
-                [key: string]: unknown;
-            } | null;
+            data?: Record<string, never> | null;
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list] */
         Envelope_list_: {
@@ -3272,9 +3156,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[ContactMapPin]] */
         Envelope_list_ContactMapPin__: {
@@ -3283,9 +3165,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[DuplicateContactData]] */
         Envelope_list_DuplicateContactData__: {
@@ -3294,9 +3174,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[FollowUpResponse]] */
         Envelope_list_FollowUpResponse__: {
@@ -3305,9 +3183,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[GoogleAccountData]] */
         Envelope_list_GoogleAccountData__: {
@@ -3316,9 +3192,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[IdentityMatchData]] */
         Envelope_list_IdentityMatchData__: {
@@ -3327,9 +3201,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[InteractionResponse]] */
         Envelope_list_InteractionResponse__: {
@@ -3338,9 +3210,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[OrgIdentityMatchData]] */
         Envelope_list_OrgIdentityMatchData__: {
@@ -3349,9 +3219,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[OrganizationResponse]] */
         Envelope_list_OrganizationResponse__: {
@@ -3360,22 +3228,16 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[dict]] */
         Envelope_list_dict__: {
             /** Data */
-            data?: {
-                [key: string]: unknown;
-            }[] | null;
+            data?: Record<string, never>[] | null;
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** Envelope[list[str]] */
         Envelope_list_str__: {
@@ -3384,9 +3246,7 @@ export interface components {
             /** Error */
             error?: string | null;
             /** Meta */
-            meta?: {
-                [key: string]: unknown;
-            } | null;
+            meta?: Record<string, never> | null;
         };
         /** FollowUpResponse */
         FollowUpResponse: {
@@ -3600,6 +3460,8 @@ export interface components {
             profile_url: string;
             /** Full Name */
             full_name: string;
+            /** Member Id */
+            member_id?: string | null;
             /** Headline */
             headline?: string | null;
             /** Company */
@@ -3625,6 +3487,11 @@ export interface components {
              * @default []
              */
             messages: components["schemas"]["LinkedInMessagePush"][];
+            /**
+             * Enrich Only
+             * @default false
+             */
+            enrich_only: boolean;
         };
         /** LinkedInPushResult */
         LinkedInPushResult: {
@@ -4167,21 +4034,13 @@ export interface components {
         /** SyncSettingsData */
         SyncSettingsData: {
             /** Telegram */
-            telegram: {
-                [key: string]: unknown;
-            };
+            telegram: Record<string, never>;
             /** Gmail */
-            gmail: {
-                [key: string]: unknown;
-            };
+            gmail: Record<string, never>;
             /** Twitter */
-            twitter: {
-                [key: string]: unknown;
-            };
+            twitter: Record<string, never>;
             /** Linkedin */
-            linkedin: {
-                [key: string]: unknown;
-            };
+            linkedin: Record<string, never>;
         };
         /**
          * SyncSettingsInput
@@ -4189,21 +4048,13 @@ export interface components {
          */
         SyncSettingsInput: {
             /** Telegram */
-            telegram?: {
-                [key: string]: unknown;
-            } | null;
+            telegram?: Record<string, never> | null;
             /** Gmail */
-            gmail?: {
-                [key: string]: unknown;
-            } | null;
+            gmail?: Record<string, never> | null;
             /** Twitter */
-            twitter?: {
-                [key: string]: unknown;
-            } | null;
+            twitter?: Record<string, never> | null;
             /** Linkedin */
-            linkedin?: {
-                [key: string]: unknown;
-            } | null;
+            linkedin?: Record<string, never> | null;
         };
         /** SyncStartedData */
         SyncStartedData: {
@@ -4396,9 +4247,7 @@ export interface components {
              */
             meta_sync_instagram: boolean;
             /** Priority Settings */
-            priority_settings?: {
-                [key: string]: unknown;
-            } | null;
+            priority_settings?: Record<string, never> | null;
         };
         /** UserWithAccountsData */
         UserWithAccountsData: {
@@ -6517,9 +6366,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
         };
@@ -8039,9 +7886,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */
@@ -8070,9 +7915,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": Record<string, never>;
                 };
             };
         };


### PR DESCRIPTION
## Problem
Opening a LinkedIn profile (e.g. `/in/mattjlam/`) synced nothing back. Investigation found three root causes:

1. **Profile visits had no capture path.** `LINKEDIN_PAGE_VISIT` only refreshed cookies + ran a throttled DM sync; `_maybeRunVoyagerSync` never called `_runPendingBackfill` (unlike the popup's `SYNC_NOW`).
2. **Company was never sent** by any path — `_runPendingBackfill` omitted the field entirely.
3. **ACo-anonymized contacts could never be enriched.** Contacts created from DMs are keyed on an `ACo…` member id that the profile endpoint rejects; backfill skips them and the push matched only by slug/url. (This is the Matt Lam contact — stored as `ACoAAAFS80wB…`, avatar/company/title all null.)

## Fix
- **Extension:** new `PROFILE_VISIT` path. Content script sends the viewed slug; the SW fetches the profile via Voyager, extracts avatar + current company (active `Position`) + headline + member id via a shared `_extractProfileFields`, and pushes an `enrich_only` profile. Per-slug throttled (10 min). Backfill refactored onto the same extractor and now also sends `company` + `member_id`.
- **Backend:** `LinkedInProfilePush.member_id` + `LinkedInPushRequest.enrich_only`. Profiles now match contacts by member id, **repair** an `ACo` `linkedin_profile_id` by upgrading it to the real slug, and skip creation when `enrich_only` (so opening a stranger's profile doesn't spam the CRM).

## Verification
- Probed the **live** Matt Lam profile: avatar + company ("Bloq") extract correctly; member id matches the stored ACo contact.
- Backend: **1331 passed** (3 new: member_id match / ACo repair / enrich_only). Extension: **23 passed** (new offline test harness).
- openapi + api-types regenerated; response-model + as-any guards pass.

## Notes
- Adds a zero-install Node test harness for the extension (`chrome-extension/test/`) — chrome.* stub + vm loader running the real service-worker code, plus a CDP-driven live capture/probe tool.
- Extension changes require reloading the unpacked extension to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)