### PR TITLE
fix(frontend): surface registration validation errors

### DIFF
--- a/frontend/src/app/auth/register/page.test.tsx
+++ b/frontend/src/app/auth/register/page.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import RegisterPage from "./page";
 
 // Mock useAuth
@@ -26,6 +26,11 @@ describe("RegisterPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRegister.mockResolvedValue(undefined);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("renders form with name, email, and password fields", () => {
@@ -49,6 +54,13 @@ describe("RegisterPage", () => {
   it("shows app name", () => {
     render(<RegisterPage />);
     expect(screen.getByText("Ping")).toBeInTheDocument();
+  });
+
+  it("communicates and enforces the password minimum", () => {
+    render(<RegisterPage />);
+
+    expect(screen.getByLabelText("Password")).toHaveAttribute("minlength", "8");
+    expect(screen.getByText("Use at least 8 characters.")).toBeInTheDocument();
   });
 
   it("calls register with correct args and redirects on success", async () => {
@@ -95,6 +107,10 @@ describe("RegisterPage", () => {
         screen.getByText("Email already registered")
       ).toBeInTheDocument();
     });
+    expect(console.error).toHaveBeenCalledWith(
+      "Registration failed",
+      expect.any(Error)
+    );
     expect(mockPush).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/app/auth/register/page.tsx
+++ b/frontend/src/app/auth/register/page.tsx
@@ -22,6 +22,7 @@ export default function RegisterPage() {
       await register(email, password, fullName);
       router.push("/dashboard");
     } catch (err: unknown) {
+      console.error("Registration failed", err);
       const message =
         err instanceof Error
           ? err.message
@@ -91,12 +92,17 @@ export default function RegisterPage() {
                 id="password"
                 type="password"
                 required
+                minLength={8}
                 autoComplete="new-password"
+                aria-describedby="password-help"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
                 placeholder="••••••••"
               />
+              <p id="password-help" className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Use at least 8 characters.
+              </p>
             </div>
 
             {error && (

--- a/frontend/src/hooks/use-auth.test.tsx
+++ b/frontend/src/hooks/use-auth.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider, useAuth } from "./use-auth";
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  client: {
+    GET: mockGet,
+    POST: mockPost,
+  },
+}));
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+describe("AuthProvider registration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs context when restoring the authenticated user fails", async () => {
+    localStorage.setItem("access_token", "expired-token");
+    mockGet.mockRejectedValueOnce(new Error("Network unavailable"));
+
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to fetch authenticated user",
+      expect.any(Error)
+    );
+  });
+
+  it("surfaces a validation error without attempting login", async () => {
+    mockPost.mockResolvedValueOnce({
+      error: {
+        detail: [
+          {
+            loc: ["body", "password"],
+            msg: "Password must be at least 8 characters",
+            type: "value_error",
+          },
+        ],
+      },
+    });
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
+
+    await expect(
+      result.current.register("jane@example.com", "short", "Jane Smith")
+    ).rejects.toThrow("Password must be at least 8 characters");
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith("/api/v1/auth/register", {
+      body: {
+        email: "jane@example.com",
+        password: "short",
+        full_name: "Jane Smith",
+      },
+    });
+  });
+});

--- a/frontend/src/hooks/use-auth.tsx
+++ b/frontend/src/hooks/use-auth.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { client } from "@/lib/api-client";
+import { extractErrorMessage } from "@/lib/api-errors";
 
 export type User = {
   id: string;
@@ -45,7 +46,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         localStorage.removeItem("access_token");
         setUser(null);
       }
-    } catch {
+    } catch (error) {
+      console.error("Failed to fetch authenticated user", error);
       localStorage.removeItem("access_token");
       setUser(null);
     } finally {
@@ -82,9 +84,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const register = useCallback(
     async (email: string, password: string, full_name: string) => {
-      await client.POST("/api/v1/auth/register", {
+      const { error } = await client.POST("/api/v1/auth/register", {
         body: { email, password, full_name },
       });
+      if (error) {
+        throw new Error(extractErrorMessage(error) ?? "Registration failed");
+      }
       await login(email, password);
     },
     [login]


### PR DESCRIPTION
## What changed

- Stop the automatic login attempt when registration returns an API error.
- Surface FastAPI validation details so users receive actionable email or password feedback.
- Add the backend-aligned eight-character password minimum and helper text to the registration form.
- Add focused regression coverage for registration failures, password validation, and contextual error logging.

## Why

While creating my own account, a failed registration was followed by an automatic login attempt, so the UI only showed a misleading “Incorrect email or password” error. This PR stops that login attempt when registration fails and surfaces the backend’s email and password validation details instead. It also adds the eight-character password requirement to the registration form, giving users clearer, actionable feedback.

The root cause was that `openapi-fetch` returns 4xx responses in `result.error` rather than throwing. The registration hook awaited the response without inspecting that error, then continued into login.

## Validation

- `vitest run`: 36 files passed, 646 tests passed.
- `tsc --noEmit`: passed.
- ESLint on all four changed files: passed.
- Focused RED → GREEN tests: 11 passed.
- Production Docker frontend build: passed.
- Isolated Compose QA: `/auth/register` and `/api/health` returned HTTP 200; manual UI review approved.

## Local verification caveats

- Backend pytest was attempted but could not start because the host test PostgreSQL service was unavailable; this PR does not change backend code.
- Repository-wide ESLint still reports the pre-existing cognitive-complexity violation in `frontend/src/app/contacts/[id]/page.tsx`; changed-file lint is clean.
