### PR TITLE
fix(compose): bind dev postgres and redis to loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,13 @@ services:
     # from a local venv, per CONTRIBUTING.md) can reach the database at
     # localhost:5432. Containers on the compose network still use the "postgres"
     # service hostname.
+    #
+    # Bound to 127.0.0.1 explicitly: "5432:5432" listens on every interface, which
+    # publishes the database to the internet on any host with a public IP. Docker
+    # writes its own iptables DNAT rules that are evaluated before ufw's, so a host
+    # firewall does not cover this.
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     command:
       - postgres
       - -c
@@ -34,8 +39,10 @@ services:
   redis:
     image: redis:7-alpine
     # Published to the host for host-based development (see postgres above).
+    # Loopback-bound for the same reason, and it matters more here: this dev Redis
+    # has no requirepass, so an all-interfaces bind is an open Redis on the internet.
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
## Problem

#117 added published ports so host-based dev (running alembic/uvicorn from a local venv) could reach the services:

```yaml
postgres:
  ports: ["5432:5432"]
redis:
  ports: ["6379:6379"]
```

The short form binds **every interface**. On any dev host with a public IP that exposes Postgres and an unauthenticated Redis to the internet. Open Redis in particular is trivially exploitable.

A host firewall does not save you here: Docker writes its own iptables DNAT rules that are evaluated ahead of ufw's, so published ports remain reachable with ufw enabled. This is the part that usually surprises people.

## Fix

Bind both to loopback. `localhost:5432` and `localhost:6379` still work for host-based alembic and uvicorn, which is what the ports were added for, and the sockets are unreachable from off-box.

## Production impact

None, and the deploy pipeline cannot propagate it. CD deploys prod on merge to main, so this was worth checking properly rather than assuming.

`.github/workflows/deploy.yml` scps `source: "docker-compose.prod.yml"` only, so the base compose file is never shipped to the server. Both compose invocations are single-file (`docker compose -f docker-compose.prod.yml pull` / `up -d`), so there is no multi-`-f` merge, which is the only way Compose would append these `ports` entries onto the prod services.

Verified on the prod host, at the socket level rather than by external scan:

- `ss -ltn` shows nothing listening on 5432 or 6379; the only all-interfaces listeners are 22, 80, and 443
- `docker ps` shows `postgres => 5432/tcp` and `redis => 6379/tcp` with no host binding, i.e. reachable on the compose network only
- only `pingcrm-caddy-1` publishes to the host (`0.0.0.0:80`, `0.0.0.0:443`)
- the server's copy of the base compose file is still dated Mar 11, predating #117, consistent with it never being synced

So this is a dev-host fix, not a prod incident.

## Out of scope

`frontend` still publishes `3000:3000` on all interfaces. Pre-existing, and a dev UI is a smaller prize than an open Redis, so leaving it for a separate call.

## Test plan

- [x] `docker-compose.yml` parses; `postgres -> ['127.0.0.1:5432:5432']`, `redis -> ['127.0.0.1:6379:6379']`
- [ ] `docker compose up`, confirm `psql -h localhost -U pingcrm pingcrm` and `redis-cli -h localhost ping` still work
- [ ] confirm the ports no longer bind externally (`ss -ltnp | grep -E '5432|6379'` shows 127.0.0.1)
