### PR TITLE
fix(api): mark every /api response no-store

### DIFF
--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -1,4 +1,4 @@
-"""FastAPI middleware for request correlation and lifecycle logging."""
+"""FastAPI middleware for request correlation, cache policy, and lifecycle logging."""
 import logging
 import time
 import uuid
@@ -10,6 +10,28 @@ from starlette.responses import Response
 from app.core.request_context import request_id_var
 
 logger = logging.getLogger("app.request")
+
+
+class NoStoreCacheMiddleware(BaseHTTPMiddleware):
+    """Mark every /api response as uncacheable.
+
+    These responses are per-user and bearer-scoped, and we sent no cache headers
+    at all, which leaves caching to heuristics. Two reasons that is wrong:
+
+    1. Privacy. A shared or corporate proxy, or the on-disk browser cache, may
+       retain one user's contacts and serve them later.
+    2. Correctness. Anything a client caches here is stale by definition, since
+       the whole point of these endpoints is current state.
+
+    Applied at the middleware layer rather than per-route so a new endpoint
+    cannot forget it.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[no-untyped-def]
+        response = await call_next(request)
+        if request.url.path.startswith("/api"):
+            response.headers["Cache-Control"] = "no-store"
+        return response
 
 
 class RequestCorrelationMiddleware(BaseHTTPMiddleware):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.config import settings
 from app.core.logging_config import setup_logging
-from app.core.middleware import RequestCorrelationMiddleware
+from app.core.middleware import NoStoreCacheMiddleware, RequestCorrelationMiddleware
 from app.core.version import APP_VERSION
 from app.api.auth import router as auth_router
 from app.api.contacts import router as contacts_router
@@ -87,6 +87,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(RequestCorrelationMiddleware)
+app.add_middleware(NoStoreCacheMiddleware)
 
 app.include_router(contacts_router)
 app.include_router(interactions_router)

--- a/backend/tests/test_cache_headers.py
+++ b/backend/tests/test_cache_headers.py
@@ -1,0 +1,40 @@
+"""API responses must never be cacheable.
+
+/api responses are per-user and bearer-scoped, and the app previously sent no
+cache headers at all, leaving caching to client heuristics. That is a privacy
+problem (a shared proxy or the on-disk browser cache can retain one user's
+contacts) and a correctness one (these endpoints exist to report current state).
+
+These tests pin the header at the middleware layer so a new endpoint cannot
+forget it.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_authenticated_api_response_is_no_store(client, auth_headers):
+    resp = await client.get("/api/v1/contacts/stats", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_api_response_is_also_no_store(client):
+    # 401s travel through the exception handler rather than the normal response
+    # path, so they need covering separately.
+    resp = await client.get("/api/v1/contacts/stats")
+
+    assert resp.status_code == 401
+    assert resp.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_is_no_store(client):
+    # /api/health is what the container healthcheck polls; a cached "healthy"
+    # would be actively misleading.
+    resp = await client.get("/api/health")
+
+    assert resp.headers["cache-control"] == "no-store"


### PR DESCRIPTION
## Problem

`/api` responses carry no cache headers at all. Verified against prod:

```
$ curl -sSD - -o /dev/null https://pingcrm.sawinyh.com/api/v1/contacts/stats | grep -ci 'cache-control|expires|pragma'
0
```

With nothing specified, caching falls to client heuristics. That is wrong here for two reasons:

- **Privacy.** These responses are per-user and bearer-scoped. An intermediary, or just the on-disk browser cache, can retain one user's contact list and serve it later.
- **Correctness.** Anything a client caches from these endpoints is stale by definition, since the endpoints exist to report current state.

## Fix

`NoStoreCacheMiddleware` sets `Cache-Control: no-store` on every `/api` response. Middleware rather than per-route decorators, so a new endpoint cannot forget it.

It covers the exception-handler path too. A 401 reaches the client differently from a 200, and that path had to be asserted separately, which is what the second test does.

## Relationship to the empty-dashboard investigation

Being explicit, since the commit message is: this is **not** confirmed as the cause of that bug and this PR does not claim to fix it.

What is true is that in the affected Chrome profile, every `fetch` I ran with `cache: 'no-store'` returned 200 with `total: 4343`, while the app's default-cache-mode requests failed, and the same page renders correctly in incognito. That correlation is what surfaced the missing headers. The mechanism is not textbook, a 503 is not supposed to be heuristically cacheable without explicit freshness headers, so timing is still a live competing explanation.

The header is correct on its own merits either way.

## Test plan

- [x] 3 new tests: authenticated 200, unauthenticated 401 (exception-handler path), and `/api/health`
- [x] Full backend suite against real Postgres + Redis: **1340 passed, 1 failed**
- [x] The one failure, `test_api_doc.py::test_api_reference_matches_openapi`, is pre-existing. Confirmed by running it against a pristine `git archive origin/main` copy containing zero occurrences of this middleware, where it fails identically.
