### PR TITLE
fix(backend): trust proxy headers so redirects keep the https scheme

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,4 +34,12 @@ USER appuser
 EXPOSE 8000
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# --forwarded-allow-ips: uvicorn only honours X-Forwarded-* from a trusted peer,
+# and defaults that trust to 127.0.0.1. Caddy reaches us over the compose network
+# (172.18.0.0/16), so the default silently discarded X-Forwarded-Proto: the app
+# believed every request was plain HTTP and built redirect Locations as http://.
+# Caddy then bounced those back to https://, producing a redirect ping-pong that
+# browsers cache as a permanent redirect. The backend is not published to the
+# host, so its only reachable peer is the proxy.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", \
+     "--proxy-headers", "--forwarded-allow-ips", "*"]


### PR DESCRIPTION
## The actual cause of the empty dashboard

The browser console says `net::ERR_TOO_MANY_REDIRECTS`, not 503. Reproduced against prod:

```
GET https://pingcrm.sawinyh.com/api/v1/contacts/stats/
  -> 307  Location: http://pingcrm.sawinyh.com/api/v1/contacts/stats     <- scheme downgrade
GET http://pingcrm.sawinyh.com/api/v1/contacts/stats
  -> 308  Location: https://pingcrm.sawinyh.com/api/v1/contacts/stats    <- Caddy upgrades back
```

The app downgrades to `http://`, Caddy upgrades to `https://`. For any path whose canonical form carries a trailing slash, that never converges.

Chrome caches the outcome as a **permanent** redirect, which is why the failure outlives the request that caused it, survives reloads, and appears in one profile but not a fresh one.

## Why it looked like a server outage for so long

It isn't one. The API is healthy and returns `total: 4343` to any request that bypasses the cache:

- Caddy logged **zero** 503s in two hours
- the backend received **2 of 8** dashboard requests, both 200 in ~11ms and ~50ms
- every `fetch` with `cache: 'no-store'` returned 200 with full data; every default-cache-mode request failed
- incognito rendered correctly

Requests served from the browser's redirect cache never hit the network at all, so nothing appeared in any server log. Cloudflare is not involved either: it is the DNS provider, but the A record is dns-only (points at the origin, not an anycast IP), there is no `cf-ray` header, and the zone has zero Worker routes.

## Root cause

uvicorn honours `X-Forwarded-*` only from a peer it trusts, and `--forwarded-allow-ips` defaults to `127.0.0.1`. Caddy reaches the backend over the compose network (`172.18.0.8`), so the header was discarded, the app concluded every request was plain HTTP, and built redirect Locations accordingly.

## Fix

Add `--proxy-headers --forwarded-allow-ips "*"` to the uvicorn CMD.

The wildcard is safe in this topology: the backend publishes no host port (`docker ps` shows bare `8000/tcp`), so the reverse proxy is its only reachable peer.

## Test plan

- [ ] After deploy, `https://pingcrm.sawinyh.com/api/v1/contacts/stats/` returns a `Location` on **https://**, not http://
- [ ] Dashboard renders real counts in a profile with cleared cache

## Note for anyone hitting this now

Deploying fixes the cause but not already-cached redirects. Clear site data for the origin once (DevTools → Application → Storage → Clear site data).
